### PR TITLE
Enable pulsar setup parameters as input options

### DIFF
--- a/Examples/Physics_applications/pulsar/inputs.corotating.3d.PM
+++ b/Examples/Physics_applications/pulsar/inputs.corotating.3d.PM
@@ -1,3 +1,19 @@
+# Description:
+#
+# This inputs file sets up a NS with these properties:
+# - 12km radius
+# - 6283 rad/s angular velocity
+# - 1e8 T magnetic field
+# - B aligned with rotation axis
+# - E = -(omega*R)[cross]B inside the NS
+# - no external fields, no monopole term, no drag force
+#
+# See the "Pulsar Setup" section at the end for the options
+#
+# This also initializes a constant density for electrons and positrons inside the NS.
+#
+# This initializes the electrons and positrons with a corotating momentum function.
+
 #################################
 ####### GENERAL PARAMETERS ######
 #################################

--- a/Examples/Physics_applications/pulsar/inputs.corotating.3d.PM
+++ b/Examples/Physics_applications/pulsar/inputs.corotating.3d.PM
@@ -1,0 +1,91 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 99000
+amr.n_cell = 128 128 128
+amr.max_grid_size = 64
+amr.blocking_factor = 64
+amr.max_level = 0
+amr.plot_file = "plotfiles/plt"
+amr.plot_int = 100
+geometry.coord_sys   = 0                  # 0: Cartesian
+geometry.is_periodic = 0 0 0     # Is periodic?
+#geometry.prob_lo     = -48000. -48000. -48000.
+#geometry.prob_hi     =  48000.  48000.  48000.
+geometry.prob_lo     =  0. 0. 0.
+geometry.prob_hi     =  96.e3  96.e3  96.e3
+
+#################################
+############ NUMERICS ###########
+#################################
+algo.maxwell_fdtd_solver = yee
+warpx.verbose = 1
+warpx.plot_raw_fields = 0
+warpx.do_dive_cleaning = 0
+warpx.use_filter = 1
+warpx.cfl = .99
+my_constants.pi    = 3.141592653589793
+my_constants.dens  = 1.0e20
+my_constants.xc  = 48.e3
+my_constants.yc  = 48.e3 
+my_constants.zc  = 48.e3
+my_constants.r_star = 12.e3
+my_constants.omega = 6283.0
+my_constants.c = 299792458. 
+interpolation.nox = 3
+interpolation.noy = 3
+interpolation.noz = 3
+
+#################################
+############ PLASMA #############
+#################################
+particles.nspecies = 2
+particles.species_names = plasma_e plasma_p
+
+plasma_e.charge = -q_e
+plasma_e.mass = m_e
+plasma_e.injection_style = "NRandomPerCell"
+# plasma_e.profile = constant
+# plasma_e.density = 1.e20
+plasma_e.profile = parse_density_function
+plasma_e.density_function(x,y,z) = "( (( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<r_star)*dens"
+plasma_e.num_particles_per_cell = 50
+plasma_e.momentum_distribution_type = parse_momentum_function
+plasma_e.momentum_function_ux(x,y,z) = "( (( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<r_star)*(-omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/((1.0-(omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/c)^2)^(0.5)) * (y-yc)/(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5)))"
+plasma_e.momentum_function_uy(x,y,z) = "( (( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<r_star)*(omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/((1.0-(omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/c)^2)^(0.5)) * (x-xc)/(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5)))"
+plasma_e.momentum_function_uz(x,y,z) = "0.0"
+plasma_e.do_continuous_injection = 0
+plasma_e.density_min = 1E0
+
+plasma_p.charge = q_e
+plasma_p.mass = m_e
+plasma_p.injection_style = "NRandomPerCell"
+# plasma_p.profile = "constant"
+# plasma_p.density = 1.e20
+plasma_p.profile = parse_density_function
+plasma_p.density_function(x,y,z) = "( (( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<r_star)*dens"
+plasma_p.num_particles_per_cell = 50
+plasma_p.momentum_distribution_type = parse_momentum_function
+plasma_p.momentum_function_ux(x,y,z) = "( (( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<r_star)*(-omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/((1.0-(omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/c)^2)^(0.5)) * (y-yc)/(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5)))"
+plasma_p.momentum_function_uy(x,y,z) = "( (( (z-zc)*(z-zc) + (y-yc)*(y-yc) + (x-xc)*(x-xc) )^(0.5))<r_star)*(omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/((1.0-(omega*(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5))/c)^2)^(0.5)) * (x-xc)/(((x-xc)*(x-xc) + (y-yc)*(y-yc))^(0.5)))"
+plasma_p.momentum_function_uz(x,y,z) = "0.0"
+plasma_p.do_continuous_injection = 0
+plasma_p.density_min = 1E0
+
+#################################
+######### PULSAR SETUP ##########
+#################################
+pulsar.use_conductor_E = 1             # [0/1]: set E = -(omega*R)[cross]B inside NS
+pulsar.use_external_E = 0              # [0/1]: use external analytic E field
+pulsar.include_external_monopole_E = 0 # [0/1]: turn off/on external E monopole term
+pulsar.use_drag_force = 0              # [0/1]: apply drag force within the NS
+pulsar.drag_force_tau = 1.0e-16        # drag force timescale (seconds)
+
+pulsar.B_omega_alignment = 1           # [1/-1]: sign of B[dot]omega
+pulsar.omega_star = 6283               # angular velocity of NS (rad/s)
+pulsar.R_star = 12.e3                  # radius of NS (m)
+pulsar.B_star = 1.0e8                  # magnetic field of NS (T)
+
+pulsar.verbose = 0                     # [0/1]: turn on verbosity for debugging print statements
+pulsar.pid_verbose = 11264000          # print particle properties for this particle ID if pulsar.verbose = 1
+

--- a/Source/Particles/ExternalForce_PM.H
+++ b/Source/Particles/ExternalForce_PM.H
@@ -2,17 +2,29 @@
 #define WARPX_EXTERNALFORCE_PM_H
 
 #include <AMReX_REAL.H>
+#include <PulsarParameters.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ApplyExternalForce(
-    const amrex::Real xp, const amrex::Real yp, const amrex::Real zp, 
+    const amrex::Real xp, const amrex::Real yp, const amrex::Real zp,
     const amrex::Real ux, const amrex::Real uy, const amrex::Real uz,
     amrex::Real& Ex, amrex::Real& Ey, amrex::Real& Ez,
     amrex::Real& Bx, amrex::Real& By, amrex::Real& Bz,
-    const amrex::Real xc, const amrex::Real yc, const amrex::Real zc, 
-    const amrex::Real q, const amrex::Real m, amrex::Real dt , const int istep, const amrex::Real wp)
+    const amrex::Real xc, const amrex::Real yc, const amrex::Real zc,
+    const amrex::Real q, const amrex::Real m, const amrex::Real wp, const long pid)
 {
+    /* physical properties of NS */
 
+    // B_omega_sign = +/-1.0, B and Omega are parallel (+1) or antiparallel (-1)
+    const amrex::Real B_omega_sign = PulsarParm::B_omega_alignment;
+
+    // omega_star = rad/s, rotation axis is k_hat*B_omega_sign
+    const amrex::Real omega_star = PulsarParm::omega_star;
+
+    const amrex::Real r_star = PulsarParm::R_star; // meters
+    const amrex::Real B_star = PulsarParm::B_star * B_omega_sign; // Tesla
+
+    /* geometry */
     // spherical radius, theta, phi and cylindrical r //
     const amrex::Real r = std::sqrt( (xp-xc)*(xp-xc) + (yp-yc)*(yp-yc) + (zp-zc)*(zp-zc));
     const amrex::Real phi = std::atan2((yp-yc),(xp-xc));
@@ -21,66 +33,95 @@ void ApplyExternalForce(
        theta = std::acos( (zp-zc)/r );
     }
     const amrex::Real r_cl = std::sin(theta) * r;
-    
-    // angular vel and radius of star 
-    const amrex::Real omega_star = 1125000. ; // rotation axis is k_hat
-    const amrex::Real r_star = 100.;
-  
-    // 
-    const amrex::Real f_drag_coeff = -1.0 * m /(q*dt*50.0);    
-    amrex::Real f_drag_ux, f_drag_uy, f_drag_uz;
-    amrex::Real B_star, c_theta, s_theta, c_phi, s_phi;
-    B_star = 1.0e8;
+
+    amrex::Real c_theta, s_theta, c_phi, s_phi;
+
     c_theta = std::cos(theta);
     s_theta = std::sin(theta);
     c_phi = std::cos(phi);
     s_phi = std::sin(phi);
-    // apply drag force only for particles inside the pulsar  
+
+    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+
+    // Compute inverse Lorentz factor
+    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+
+    /* print particle data before fields if pid is pid_verbose_external list */
+    if (PulsarParm::verbose_external && pid == PulsarParm::pid_verbose_external) {
+        amrex::Print() << "***** before ext force *** \n";
+        amrex::Print() << " r " << r << "\n";
+        amrex::Print() << " theta " << theta << "\n";
+        amrex::Print() << " phi " << phi << "\n";
+        amrex::Print() << " vel " << ux*inv_gamma << " " << uy*inv_gamma << " " << uz*inv_gamma << "\n";
+        amrex::Print() << " xy speed " << std::sqrt(ux*ux*inv_gamma*inv_gamma + uy*uy*inv_gamma*inv_gamma ) << "\n";
+        amrex::Print() << " r*omega " << r*s_theta*omega_star << "\n";;
+    }
+
+    /* Internal forces and fields */
     if (r <= r_star*1.001)
     {
+        if (PulsarParm::use_drag_force) {
+            // drag force quantities
+            const amrex::Real f_drag_coeff = -1.0 * m /(q * PulsarParm::drag_force_tau);
+            amrex::Real f_drag_ux, f_drag_uy, f_drag_uz;
 
-        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+            f_drag_ux = ux*inv_gamma - (-1.0)*(r_cl/r_star)*r_star*omega_star*std::sin(phi);
+            f_drag_uy = uy*inv_gamma - (r_cl/r_star)*r_star*omega_star*std::cos(phi);
+            f_drag_uz = uz*inv_gamma - 0.0;
 
-        // Compute inverse Lorentz factor
-        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+            // Electric field equivalent to drag force
+            Ex += f_drag_coeff * f_drag_ux ;
+            Ey += f_drag_coeff * f_drag_uy ;
+            Ez += f_drag_coeff * f_drag_uz;
+        }
 
-        f_drag_ux = ux*inv_gamma - (-1.0)*(r_cl/r_star)*r_star*omega_star*std::sin(phi);
-        f_drag_uy = uy*inv_gamma - (r_cl/r_star)*r_star*omega_star*std::cos(phi);
-        f_drag_uz = uz*inv_gamma - 0.0;
- 
-        Ex += f_drag_coeff * f_drag_ux ;
-        Ey += f_drag_coeff * f_drag_uy ;
-        Ez += f_drag_coeff * f_drag_uz;
-//        Ex -= (-1.0)*B_star*2.0*r_cl*omega_star*c_phi;
-//        Ey -= (-1.0)*B_star*2.0*r_cl*omega_star*s_phi;
+        if (PulsarParm::use_conductor_E) {
+            // Electric field for a good conductor in steady state E = -(omega*rcyl)[cross]B
+            Ex += (r_cl * omega_star) * (2.0 * B_star) * c_phi;
+            Ey += (r_cl * omega_star) * (2.0 * B_star) * s_phi;
+            Ez += 0.0;
+        }
 
+        // Uniform internal B field
+        Bx += 0.0;
+        By += 0.0;
+        Bz += B_star * 2.0;
     }
-    if(r <= r_star*1.001)
+
+    /* External forces and fields */
+    if(r > r_star*1.001)
     {
-           Bx += 0.0;
-           By += 0.0;
-           Bz += B_star*2.0; 
-    }
-    // External E and B field that correspond to a magnetic dipole //
-    if(r > (r_star*1.001))
-    {
+        amrex::Real r_ratio = r_star/r;
+        amrex::Real r3 = r_ratio*r_ratio*r_ratio;
+        amrex::Real B_r = 2.0*B_star*r3*c_theta;
+        amrex::Real B_theta = B_star*r3*s_theta;
 
-           amrex::Real r_ratio = r_star/r;
-           amrex::Real r3 = r_ratio*r_ratio*r_ratio;
-           amrex::Real B_r = 2.0*B_star*r3*c_theta;
-           amrex::Real B_theta = B_star*r3*s_theta;
-           Bx += B_r*c_phi*s_theta + B_theta*c_phi*c_theta;
-           By += B_r*s_phi*s_theta + B_theta*s_phi*c_theta;
-           Bz += B_r*c_theta - B_theta*s_theta;
-           amrex::Real E_r ;
-           E_r = omega_star*r_star*B_star*r3*r_ratio*(1.0-3.0*c_theta*c_theta) ;
-//                             + (2.0/3.0)*omega_star*B_star*r_star*r_ratio*r_ratio;
-           amrex::Real E_theta = (-1.0)*omega_star*B_star*r_star*r3*r_ratio*(c_theta*s_theta*2.0);
-           Ex += E_r*c_phi*s_theta + E_theta*c_phi*c_theta;
-           Ey += E_r*s_phi*s_theta + E_theta*s_phi*c_theta;
-           Ez += 1.0*E_r*c_theta - (1.0)*E_theta*s_theta;
+        // Dipole B field
+        Bx += B_r*c_phi*s_theta + B_theta*c_phi*c_theta;
+        By += B_r*s_phi*s_theta + B_theta*s_phi*c_theta;
+        Bz += B_r*c_theta - B_theta*s_theta;
+
+        if (PulsarParm::use_external_E) {
+            amrex::Real E_r = omega_star*r_star*B_star*r3*r_ratio*(1.0-3.0*c_theta*c_theta);
+
+            if (PulsarParm::include_external_monopole_E)
+                E_r += (2.0/3.0)*omega_star*B_star*r_star*r_ratio*r_ratio;
+
+            amrex::Real E_theta = (-1.0)*omega_star*B_star*r_star*r3*r_ratio*(c_theta*s_theta*2.0);
+
+            Ex += E_r*c_phi*s_theta + E_theta*c_phi*c_theta;
+            Ey += E_r*s_phi*s_theta + E_theta*s_phi*c_theta;
+            Ez += 1.0*E_r*c_theta - (1.0)*E_theta*s_theta;
+        }
     }
 
+    /* print particle data after fields if pid is pid_verbose_external list */
+    if (PulsarParm::verbose_external && pid == PulsarParm::pid_verbose_external) {
+        amrex::Print() << " **** after ext force **** \n" ;
+        amrex::Print() << " Efield " << Ex << " " << Ey << " " << Ez << "\n";
+        amrex::Print() << " Bfield " << Bx << " " << By << " " << Bz << "\n";
+        amrex::Print() << " q " << q << "\n";
+    }
 }
 
 #endif

--- a/Source/Particles/ExternalForce_PM.H
+++ b/Source/Particles/ExternalForce_PM.H
@@ -46,8 +46,8 @@ void ApplyExternalForce(
     // Compute inverse Lorentz factor
     const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
 
-    /* print particle data before fields if pid is pid_verbose_external list */
-    if (PulsarParm::verbose_external && pid == PulsarParm::pid_verbose_external) {
+    /* print particle data before fields if pid is pid_verbose list */
+    if (PulsarParm::verbose && pid == PulsarParm::pid_verbose) {
         amrex::Print() << "***** before ext force *** \n";
         amrex::Print() << " r " << r << "\n";
         amrex::Print() << " theta " << theta << "\n";
@@ -115,8 +115,8 @@ void ApplyExternalForce(
         }
     }
 
-    /* print particle data after fields if pid is pid_verbose_external list */
-    if (PulsarParm::verbose_external && pid == PulsarParm::pid_verbose_external) {
+    /* print particle data after fields if pid is pid_verbose list */
+    if (PulsarParm::verbose && pid == PulsarParm::pid_verbose) {
         amrex::Print() << " **** after ext force **** \n" ;
         amrex::Print() << " Efield " << Ex << " " << Ey << " " << Ez << "\n";
         amrex::Print() << " Bfield " << Bx << " " << By << " " << Bz << "\n";

--- a/Source/Particles/Make.package
+++ b/Source/Particles/Make.package
@@ -10,6 +10,9 @@ CEXE_headers += WarpXParticleContainer.H
 CEXE_headers += RigidInjectedParticleContainer.H
 CEXE_headers += PhysicalParticleContainer.H
 CEXE_headers += ShapeFactors.H
+
+CEXE_sources += PulsarParameters.cpp
+CEXE_headers += PulsarParameters.H
 CEXE_headers += ExternalForce_PM.H
 
 include $(WARPX_HOME)/Source/Particles/Pusher/Make.package

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1617,17 +1617,16 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
             pti.numParticles(),
             [=] AMREX_GPU_DEVICE (long i) {
                 auto& p = particles[i];
-                if (false){
-                    //amrex::Print() << " pid " << p.id() << "\n";
-                    //amrex::Print() << " before mom boris\n";
-                    //amrex::Print() << " position " << x[i] << " ";
-                    //amrex::Print() << y[i] << " " << z[i] << "\n";
-                    //    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+                if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
+                    amrex::Print() << " ***** before mom boris pushpx ****\n";
+                    amrex::Print() << " position " << x[i] << " ";
+                    amrex::Print() << y[i] << " " << z[i] << "\n";
+                    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
-                    //    // Compute inverse Lorentz factor
-                    //    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
-                    //amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
-                    //amrex::Print() << " " << uz[i]*inv_gamma << "\n";
+                    // Compute inverse Lorentz factor
+                    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
+                    amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
+                    amrex::Print() << " " << uz[i]*inv_gamma << "\n";
                     amrex::Print() << " EF " << Ex[i];
                     amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
                     amrex::Print() << " Bfield " << Bx[i];
@@ -1637,33 +1636,33 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
                 if (ion_lev){ qp *= ion_lev[i]; }
                 UpdateMomentumBoris( ux[i], uy[i], uz[i], gi[i],
                       Ex[i], Ey[i], Ez[i], Bx[i], By[i], Bz[i], q, m, dt);
-                if (false){
-                        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+                if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
+                    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
-                        // Compute inverse Lorentz factor
-                        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
-                    amrex::Print() << " *****after mom boris pushpx****\n";
-                    //amrex::Print() << " position " << x[i] << " ";
-                    //amrex::Print() << y[i] << " " << z[i] << "\n";
+                    // Compute inverse Lorentz factor
+                    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
+                    amrex::Print() << " ***** after mom boris pushpx ****\n";
+                    amrex::Print() << " position " << x[i] << " ";
+                    amrex::Print() << y[i] << " " << z[i] << "\n";
                     amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
                     amrex::Print() << " " << uz[i]*inv_gamma << "\n";
-                    //amrex::Print() << " EF " << Ex[i];
-                    //amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
+                    amrex::Print() << " EF " << Ex[i];
+                    amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
                 }
                 UpdatePosition( x[i], y[i], z[i],
                       ux[i], uy[i], uz[i], dt );
-                if (false){
+                if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
                     amrex::Print() << " ***** after update pos pushpx *****\n";
                     amrex::Print() << " position " << x[i] << " ";
                     amrex::Print() << y[i] << " " << z[i] << "\n";
-                    //    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+                    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
-                    //    // Compute inverse Lorentz factor
-                    //    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
-                    //amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
-                    //amrex::Print() << " " << uz[i]*inv_gamma << "\n";
-                    //amrex::Print() << " EF " << Ex[i];
-                    //amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
+                    // Compute inverse Lorentz factor
+                    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
+                    amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
+                    amrex::Print() << " " << uz[i]*inv_gamma << "\n";
+                    amrex::Print() << " EF " << Ex[i];
+                    amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
                 }
             }
         );
@@ -1803,83 +1802,84 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 amrex::ParallelFor( pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
                      auto& p = particless[i];
-                     if (false){
-                         //amrex::Print() << " before mom boris\n";
-                         //amrex::Print() << " position " << xp_pm[i] << " ";
-                         //amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
-                         //constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
+                     if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
+                        amrex::Print() << " ***** before mom boris ****\n";
+                        amrex::Print() << " position " << xp_pm[i] << " ";
+                        amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
+                        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
-                        //// Compute inverse Lorentz factor
-                        //const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         //amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
-                         //amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;
-                         amrex::Print() << " " << Eypp[i] << " " << Ezpp[i] << "\n";
-                         //amrex::Print() << " Bfield " << Bxpp[i] ;
-                         //amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
-                         //amrex::Print() << " q_pm " << q << "\n";
-                         amrex::Print() << " Bfield " << Bxpp[i];
-                         amrex::Print() << " " << Bypp[i] << " " << Bzpp[i] << "\n";
+                        {
+                            // Compute inverse Lorentz factor
+                            const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
+                            amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
+                            amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
+                            amrex::Print() << " Efield " << Expp_pm[i] ;
+                            amrex::Print() << " " << Eypp[i] << " " << Ezpp[i] << "\n";
+                            amrex::Print() << " Bfield " << Bxpp[i] ;
+                            amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
+                            amrex::Print() << " q_pm " << q << "\n";
+                            amrex::Print() << " Bfield " << Bxpp[i];
+                            amrex::Print() << " " << Bypp[i] << " " << Bzpp[i] << "\n";
+                        }
 
-                         const amrex::Real econst = 0.5*q*dt/m;
+                        const amrex::Real econst = 0.5*q*dt/m;
 
-                         // First half-push for E
-                         amrex::Real ux = 0.0;  ux += econst*Expp_pm[i];
-                         amrex::Real uy = 0.0;  uy += econst*Eypp_pm[i];
-                         amrex::Real uz = 0.0;  uz += econst*Ezpp_pm[i];
-                         amrex::Print() << " my vel 1 " << ux << " " << uy << " " << uz << "\n";
-                         // Compute temporary gamma factor
-                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
-                         // Magnetic rotation
-                         // - Compute temporary variables
-                         const amrex::Real tx = econst*inv_gamma*Bxpp_pm[i];
-                         const amrex::Real ty = econst*inv_gamma*Bypp_pm[i];
-                         const amrex::Real tz = econst*inv_gamma*Bzpp_pm[i];
-                         const amrex::Real tsqi = 2./(1. + tx*tx + ty*ty + tz*tz);
-                         const amrex::Real sx = tx*tsqi;
-                         const amrex::Real sy = ty*tsqi;
-                         const amrex::Real sz = tz*tsqi;
-                         const amrex::Real ux_p = ux + uy*tz - uz*ty;
-                         const amrex::Real uy_p = uy + uz*tx - ux*tz;
-                         const amrex::Real uz_p = uz + ux*ty - uy*tx;
-                         amrex::Print() << " tx " << tx << " " << ty << " " << tz << "\n";
-                         amrex::Print() << " sx " << sx << " " << sy << " " << sz << "\n";
-                         amrex::Print() << " uxp " << ux_p << " " << uy_p << " " << uz_p << "\n";
-                         // - Update momentum
-                         ux += uy_p*sz - uz_p*sy;
-                         uy += uz_p*sx - ux_p*sz;
-                         uz += ux_p*sy - uy_p*sx;
-                         amrex::Print() << " my vel 2 " << ux << " " << uy << " " << uz << "\n";
-                         amrex::Print() << " epush  " << econst*Expp_pm[i]  ;
-                         amrex::Print() << " " << econst*Eypp_pm[i] << " ";
-                         amrex::Print() << " " << econst*Ezpp_pm[i] << "\n";
-                         // Second half-push for E
-                         ux += econst*Expp_pm[i];
-                         uy += econst*Eypp_pm[i];
-                         uz += econst*Ezpp_pm[i];
-                         amrex::Print() << " my vel 3 " << ux << " " << uy << " " << uz << "\n";
-                         amrex::Real tgaminv = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
-                         amrex::Print() << " my vel  " << ux << " " << uy << " " << uz << "\n";
+                        // First half-push for E
+                        amrex::Real ux = 0.0;  ux += econst*Expp_pm[i];
+                        amrex::Real uy = 0.0;  uy += econst*Eypp_pm[i];
+                        amrex::Real uz = 0.0;  uz += econst*Ezpp_pm[i];
+                        amrex::Print() << " my vel 1 " << ux << " " << uy << " " << uz << "\n";
+                        // Compute temporary gamma factor
+                        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+                        // Magnetic rotation
+                        // - Compute temporary variables
+                        const amrex::Real tx = econst*inv_gamma*Bxpp_pm[i];
+                        const amrex::Real ty = econst*inv_gamma*Bypp_pm[i];
+                        const amrex::Real tz = econst*inv_gamma*Bzpp_pm[i];
+                        const amrex::Real tsqi = 2./(1. + tx*tx + ty*ty + tz*tz);
+                        const amrex::Real sx = tx*tsqi;
+                        const amrex::Real sy = ty*tsqi;
+                        const amrex::Real sz = tz*tsqi;
+                        const amrex::Real ux_p = ux + uy*tz - uz*ty;
+                        const amrex::Real uy_p = uy + uz*tx - ux*tz;
+                        const amrex::Real uz_p = uz + ux*ty - uy*tx;
+                        amrex::Print() << " tx " << tx << " " << ty << " " << tz << "\n";
+                        amrex::Print() << " sx " << sx << " " << sy << " " << sz << "\n";
+                        amrex::Print() << " uxp " << ux_p << " " << uy_p << " " << uz_p << "\n";
+                        // - Update momentum
+                        ux += uy_p*sz - uz_p*sy;
+                        uy += uz_p*sx - ux_p*sz;
+                        uz += ux_p*sy - uy_p*sx;
+                        amrex::Print() << " my vel 2 " << ux << " " << uy << " " << uz << "\n";
+                        amrex::Print() << " epush  " << econst*Expp_pm[i]  ;
+                        amrex::Print() << " " << econst*Eypp_pm[i] << " ";
+                        amrex::Print() << " " << econst*Ezpp_pm[i] << "\n";
+                        // Second half-push for E
+                        ux += econst*Expp_pm[i];
+                        uy += econst*Eypp_pm[i];
+                        uz += econst*Ezpp_pm[i];
+                        amrex::Print() << " my vel 3 " << ux << " " << uy << " " << uz << "\n";
+                        amrex::Real tgaminv = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
+                        amrex::Print() << " my vel  " << ux << " " << uy << " " << uz << "\n";
                      }
                         UpdateMomentumBoris( ux[i], uy[i], uz[i], gi[i],
                               Expp[i], Eypp[i], Ezpp[i], Bxpp[i], Bypp[i], Bzpp[i], q, m, dt);
 
-                     if (false){
-                         //amrex::Print() << " after mom boris\n";
-                         //amrex::Print() << " position " << xp_pm[i] << " ";
-                         //amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
+                     if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
+                        amrex::Print() << " ***** after mom boris ****\n";
+                        amrex::Print() << " position " << xp_pm[i] << " ";
+                        amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
-                         amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         //amrex::Print() << " Efield " << Expp_pm[i] ;
-                         //amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         //amrex::Print() << " Bfield " << Bxpp_pm[i] ;
-                         //amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
-                         //amrex::Print() << " q_pm " << q << "\n";
+                        amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
+                        amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
+                        amrex::Print() << " Efield " << Expp_pm[i] ;
+                        amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
+                        amrex::Print() << " Bfield " << Bxpp_pm[i] ;
+                        amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
+                        amrex::Print() << " q_pm " << q << "\n";
                      }
 
                     }
@@ -1888,37 +1888,37 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 amrex::ParallelFor( pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
                      auto& p = particles[i];
-                     if (false){
-                         amrex::Print() << " before mom vay\n";
-                         amrex::Print() << " position " << xp_pm[i] << " ";
-                         amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
+                     if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
+                        amrex::Print() << " ***** before mom vay ****\n";
+                        amrex::Print() << " position " << xp_pm[i] << " ";
+                        amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
-                         amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;
-                         amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;
-                         amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
+                        amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
+                        amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
+                        amrex::Print() << " Efield " << Expp_pm[i] ;
+                        amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
+                        amrex::Print() << " Bfield " << Bxpp_pm[i] ;
+                        amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
                      }
                         UpdateMomentumVay( ux[i], uy[i], uz[i], gi[i],
                               Expp[i], Eypp[i], Ezpp[i], Bxpp[i], Bypp[i], Bzpp[i], q, m, dt);
-                     if (false){
-                         amrex::Print() << " before mom vay\n";
-                         amrex::Print() << " position " << xp_pm[i] << " ";
-                         amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
+                     if (PulsarParm::verbose && p.id() == PulsarParm::pid_verbose) {
+                        amrex::Print() << " ***** after mom vay ****\n";
+                        amrex::Print() << " position " << xp_pm[i] << " ";
+                        amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
-                         amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;
-                         amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;
-                         amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
+                        amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
+                        amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
+                        amrex::Print() << " Efield " << Expp_pm[i] ;
+                        amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
+                        amrex::Print() << " Bfield " << Bxpp_pm[i] ;
+                        amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
                      }
                     }
                 );

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -35,7 +35,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp.query("do_splitting", do_splitting);
     pp.query("split_type", split_type);
     pp.query("do_continuous_injection", do_continuous_injection);
-    // Whether to plot back-transformed (lab-frame) diagnostics 
+    // Whether to plot back-transformed (lab-frame) diagnostics
     // for this species.
     pp.query("do_boosted_frame_diags", do_boosted_frame_diags);
 
@@ -52,7 +52,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     do_user_plot_vars = pp.queryarr("plot_vars", plot_vars);
     if (not do_user_plot_vars){
         // By default, all particle variables are dumped to plotfiles,
-        // including {x,y,z,ux,uy,uz}old variables when running in a 
+        // including {x,y,z,ux,uy,uz}old variables when running in a
         // boosted frame
         if (WarpX::do_boosted_frame_diagnostic && do_boosted_frame_diags){
             plot_flags.resize(PIdx::nattribs + 6, 1);
@@ -69,9 +69,9 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         // If not none, set plot_flags values to 1 for elements in plot_vars.
         if (plot_vars[0] != "none"){
             for (const auto& var : plot_vars){
-                // Return error if var not in PIdx. 
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE( 
-                    ParticleStringNames::to_index.count(var), 
+                // Return error if var not in PIdx.
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    ParticleStringNames::to_index.count(var),
                     "plot_vars argument not in ParticleStringNames");
                 plot_flags[ParticleStringNames::to_index.at(var)] = 1;
             }
@@ -143,7 +143,7 @@ void PhysicalParticleContainer::MapParticletoBoostedFrame(Real& x, Real& y, Real
 void
 PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
                                            Real x_rms, Real y_rms, Real z_rms,
-                                           Real q_tot, long npart, 
+                                           Real q_tot, long npart,
                                            int do_symmetrize) {
 
     const Geometry& geom     = m_gdb->Geom(0);
@@ -155,7 +155,7 @@ PhysicalParticleContainer::AddGaussianBeam(Real x_m, Real y_m, Real z_m,
     std::normal_distribution<double> distz(z_m, z_rms);
 
     if (ParallelDescriptor::IOProcessor()) {
-        // If do_symmetrize, create 4x fewer particles, and 
+        // If do_symmetrize, create 4x fewer particles, and
         // Replicate each particle 4 times (x,y) (-x,y) (x,-y) (-x,-y)
         if (do_symmetrize){
             npart /= 4;
@@ -387,11 +387,11 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         const int tile_id = mfi.LocalTileIndex();
 
         // Max number of new particles, if particles are created in the whole
-        // overlap_box. All of them are created, and invalid ones are then 
+        // overlap_box. All of them are created, and invalid ones are then
         // discaded
         int max_new_particles = overlap_box.numPts() * num_ppc;
 
-        // If refine injection, build pointer dp_cellid that holds pointer to 
+        // If refine injection, build pointer dp_cellid that holds pointer to
         // array of refined cell IDs.
         Vector<int> cellid_v;
         if (refine_injection and lev == 0)
@@ -446,7 +446,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
         if (do_field_ionization) {
             pi = soa.GetIntData(particle_icomps["ionization_level"]).data() + old_size;
         }
-        
+
         const GpuArray<Real,AMREX_SPACEDIM> overlap_corner
             {AMREX_D_DECL(overlap_realbox.lo(0),
                           overlap_realbox.lo(1),
@@ -458,9 +458,9 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
 	bool loc_do_field_ionization = do_field_ionization;
 	int loc_ionization_initial_level = ionization_initial_level;
 
-        // Loop over all new particles and inject them (creates too many 
+        // Loop over all new particles and inject them (creates too many
         // particles, in particular does not consider xmin, xmax etc.).
-        // The invalid ones are given negative ID and are deleted during the 
+        // The invalid ones are given negative ID and are deleted during the
         // next redistribute.
         amrex::For(max_new_particles, [=] AMREX_GPU_DEVICE (int ip) noexcept
         {
@@ -615,7 +615,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
             p.pos(1) = z;
 #endif
         }, shared_mem_bytes);
-    			 
+
         if (cost) {
             wt = (amrex::second() - wt) / tile_box.d_numPts();
             Array4<Real> const& costarr = cost->array(mfi);
@@ -853,7 +853,7 @@ PhysicalParticleContainer::FieldGather (int lev,
     MultiFab* cost = WarpX::getCosts(lev);
 
 #ifdef _OPENMP
-#pragma omp parallel 
+#pragma omp parallel
 #endif
     {
 #ifdef _OPENMP
@@ -898,7 +898,9 @@ PhysicalParticleContainer::FieldGather (int lev,
             // copy data from particle container to temp arrays
             //
             pti.GetPosition(m_xp[thread_num], m_yp[thread_num], m_zp[thread_num]);
-            
+
+            // For Pulsar //
+            // find center of pulsar //
             const Real xc = (Geom(0).ProbHi(0) - Geom(0).ProbLo(0))/2.0;
             const Real yc = (Geom(0).ProbHi(1) - Geom(0).ProbLo(1))/2.0;
             const Real zc = (Geom(0).ProbHi(2) - Geom(0).ProbLo(2))/2.0;
@@ -918,24 +920,22 @@ PhysicalParticleContainer::FieldGather (int lev,
             Real* const AMREX_RESTRICT wp_pm = wp.dataPtr();
             const Real q_pm = this->charge;
             const Real m_pm = this-> mass;
-            Real t = WarpX::GetInstance().gett_new(lev);
-            Real dt = 1.489511617e-8;
-            int istep = t/dt;
 
             amrex::ParallelFor(pti.numParticles(),
                  [=] AMREX_GPU_DEVICE (long i) {
                  ApplyExternalForce(xp_pm[i],yp_pm[i],zp_pm[i],
                                ux_pm[i],uy_pm[i],uz_pm[i],Expp_pm[i],Eypp_pm[i],
                                Ezpp_pm[i],Bxpp_pm[i],Bypp_pm[i],Bzpp_pm[i],
-                               xc,yc,zc,q_pm,m_pm,dt,istep,wp_pm[i]);
+                               xc,yc,zc,q_pm,m_pm,wp_pm[i],-1);
             });
+
             //
             // Field Gather
             //
             int e_is_nodal = Ex.is_nodal() and Ey.is_nodal() and Ez.is_nodal();
             FieldGather(pti, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                        &exfab, &eyfab, &ezfab, &bxfab, &byfab, &bzfab, 
-                        Ex.nGrow(), e_is_nodal, 0, np, thread_num, lev, lev); 
+                        &exfab, &eyfab, &ezfab, &bxfab, &byfab, &bzfab,
+                        Ex.nGrow(), e_is_nodal, 0, np, thread_num, lev, lev);
             if (cost) {
                 const Box& tbx = pti.tilebox();
                 wt = (amrex::second() - wt) / tbx.d_numPts();
@@ -967,11 +967,11 @@ PhysicalParticleContainer::Evolve (int lev,
     BL_PROFILE_VAR_NS("PPC::FieldGather", blp_fg);
     BL_PROFILE_VAR_NS("PPC::ParticlePush", blp_ppc_pp);
     BL_PROFILE_VAR_NS("PPC::Evolve::partition", blp_partition);
-    
+
     const std::array<Real,3>& dx = WarpX::CellSize(lev);
     const std::array<Real,3>& cdx = WarpX::CellSize(std::max(lev-1,0));
 
-    // Get instances of NCI Godfrey filters 
+    // Get instances of NCI Godfrey filters
     const auto& nci_godfrey_filter_exeybz = WarpX::GetInstance().nci_godfrey_filter_exeybz;
     const auto& nci_godfrey_filter_bxbyez = WarpX::GetInstance().nci_godfrey_filter_bxbyez;
 
@@ -996,9 +996,9 @@ PhysicalParticleContainer::Evolve (int lev,
                 tmp_particle_data[lev][index][i].resize(np);
         }
     }
-    
+
 #ifdef _OPENMP
-#pragma omp parallel 
+#pragma omp parallel
 #endif
     {
 #ifdef _OPENMP
@@ -1108,13 +1108,14 @@ PhysicalParticleContainer::Evolve (int lev,
             BL_PROFILE_VAR_START(blp_copy);
             pti.GetPosition(m_xp[thread_num], m_yp[thread_num], m_zp[thread_num]);
             BL_PROFILE_VAR_STOP(blp_copy);
+
             // For Pulsar //
-            // spin particles 
             // find center of pulsar //
             auto& particles = pti.GetArrayOfStructs();
             const Real xc = (Geom(0).ProbHi(0) - Geom(0).ProbLo(0))/2.0;
             const Real yc = (Geom(0).ProbHi(1) - Geom(0).ProbLo(1))/2.0;
             const Real zc = (Geom(0).ProbHi(2) - Geom(0).ProbLo(2))/2.0;
+
             // Pointers to position, velocity, and particle field //
             Real* const AMREX_RESTRICT xp_pm = m_xp[thread_num].dataPtr();
             Real* const AMREX_RESTRICT yp_pm = m_yp[thread_num].dataPtr();
@@ -1131,54 +1132,14 @@ PhysicalParticleContainer::Evolve (int lev,
             Real* const AMREX_RESTRICT wp_pm = wp.dataPtr();
             const Real q_pm = this->charge;
             const Real m_pm = this-> mass;
-            Real t = WarpX::GetInstance().gett_new(lev);
-            int istep = t/dt;
             amrex::ParallelFor(pti.numParticles(),
                  [=] AMREX_GPU_DEVICE (long i) {
                      auto& p = particles[i];
-                     if (p.id() == 11264000 || p.id() == 198451201){
-                        const amrex::Real r = std::sqrt( (xp_pm[i]-xc)*(xp_pm[i]-xc) + 
-                                                         (yp_pm[i]-yc)*(yp_pm[i]-yc) + 
-                                                         (zp_pm[i]-zc)*(zp_pm[i]-zc));
-                        const amrex::Real phi = std::atan2((yp_pm[i]-yc),(xp_pm[i]-xc));
-                        amrex::Real theta = 0.0;
-                        if (r>0) {
-                           theta = std::acos( (zp_pm[i]-zc)/r );
-                        }
-                        amrex::Real c_theta = std::cos(theta);
-                        amrex::Real s_theta = std::sin(theta);
-                        amrex::Real c_phi = std::cos(phi);
-                        amrex::Real s_phi = std::sin(phi);
 
-                        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-
-                        // Compute inverse Lorentz factor
-                        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << "***** before ext force t = " << t << " istep " << istep <<"*** \n" ;
-                         amrex::Print() << " r " << r << " dt " << dt <<  "\n"; 
-                         amrex::Print() << " theta " << theta << " phi " << phi << "\n";
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ; 
-                         amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         const amrex::Real omega_star = 11250;
-                         amrex::Print() << " speed " << std::sqrt(ux_pm[i]*ux_pm[i]*inv_gamma*inv_gamma + uy_pm[i]*uy_pm[i]*inv_gamma*inv_gamma ) << " romega " << r*s_theta*omega_star << "\n";;
-                     }
-                     
                      ApplyExternalForce(xp_pm[i],yp_pm[i],zp_pm[i],
                           ux_pm[i],uy_pm[i],uz_pm[i],Expp_pm[i],Eypp_pm[i],
                           Ezpp_pm[i],Bxpp_pm[i],Bypp_pm[i],Bzpp_pm[i],
-                          xc,yc,zc,q_pm,m_pm,dt,istep,wp_pm[i]);
-                     if (p.id() == 11264000 || p.id() == 198451201){
-                        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-
-                        // Compute inverse Lorentz factor
-                        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " **** after ext force **** \n" ;
-                         amrex::Print() << " Efield " << Expp_pm[i] ;  
-                         amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;  
-                         amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
-                         amrex::Print() << " q_pm " << q_pm << "\n";
-                     }
+                          xc,yc,zc,q_pm,m_pm,wp_pm[i],p.id());
             });
 
 
@@ -1274,7 +1235,7 @@ PhysicalParticleContainer::Evolve (int lev,
             }
 
             const long np_current = (cjx) ? nfine_current : np;
-            
+
             //
             // copy data from particle container to temp arrays
             //
@@ -1290,14 +1251,14 @@ PhysicalParticleContainer::Evolve (int lev,
                 } else {
                     ion_lev = nullptr;
                 }
-                DepositCharge(pti, wp, ion_lev, rho, 0, 0, 
+                DepositCharge(pti, wp, ion_lev, rho, 0, 0,
                               np_current, thread_num, lev, lev);
                 if (has_buffer){
                     DepositCharge(pti, wp, ion_lev, crho, 0, np_current,
                                   np-np_current, thread_num, lev, lev-1);
                 }
             }
-            
+
             if (! do_not_push)
             {
                 const long np_gather = (cEx) ? nfine_gather : np;
@@ -1308,7 +1269,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 // Field Gather of Aux Data (i.e., the full solution)
                 BL_PROFILE_VAR_START(blp_fg);
                 FieldGather(pti, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                            exfab, eyfab, ezfab, bxfab, byfab, bzfab, 
+                            exfab, eyfab, ezfab, bxfab, byfab, bzfab,
                             Ex.nGrow(), e_is_nodal, 0, np_gather, thread_num, lev, lev);
                 if (np_gather < np)
                 {
@@ -1322,7 +1283,7 @@ PhysicalParticleContainer::Evolve (int lev,
                     FArrayBox const* cbxfab = &(*cBx)[pti];
                     FArrayBox const* cbyfab = &(*cBy)[pti];
                     FArrayBox const* cbzfab = &(*cBz)[pti];
-                    
+
                     if (WarpX::use_fdtd_nci_corr)
                     {
 #if (AMREX_SPACEDIM == 2)
@@ -1360,13 +1321,13 @@ PhysicalParticleContainer::Evolve (int lev,
                         eyeli = filtered_Ey.elixir();
                         nci_godfrey_filter_exeybz[lev-1]->ApplyStencil(filtered_Ey, (*cEy)[pti], filtered_Ey.box());
                         ceyfab = &filtered_Ey;
-                        
+
                         // Filter Bx
                         filtered_Bx.resize(amrex::convert(tbox,WarpX::Bx_nodal_flag));
                         bxeli = filtered_Bx.elixir();
                         nci_godfrey_filter_bxbyez[lev-1]->ApplyStencil(filtered_Bx, (*cBx)[pti], filtered_Bx.box());
                         cbxfab = &filtered_Bx;
-                        
+
                         // Filter Bz
                         filtered_Bz.resize(amrex::convert(tbox,WarpX::Bz_nodal_flag));
                         bzeli = filtered_Bz.elixir();
@@ -1374,14 +1335,14 @@ PhysicalParticleContainer::Evolve (int lev,
                         cbzfab = &filtered_Bz;
 #endif
                     }
-                    
+
                     // Field gather for particles in gather buffers
                     e_is_nodal = cEx->is_nodal() and cEy->is_nodal() and cEz->is_nodal();
-                        FieldGather(pti, Exp, Eyp, Ezp, Bxp, Byp, Bzp, 
+                        FieldGather(pti, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                     cexfab, ceyfab, cezfab,
                                     cbxfab, cbyfab, cbzfab,
-                                    cEx->nGrow(), e_is_nodal, 
-                                    nfine_gather, np-nfine_gather, 
+                                    cEx->nGrow(), e_is_nodal,
+                                    nfine_gather, np-nfine_gather,
                                     thread_num, lev, lev-1);
                 }
 
@@ -1391,7 +1352,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 // Particle Push
                 //
                 BL_PROFILE_VAR_START(blp_ppc_pp);
-                PushPX(pti, m_xp[thread_num], m_yp[thread_num], m_zp[thread_num], 
+                PushPX(pti, m_xp[thread_num], m_yp[thread_num], m_zp[thread_num],
                        m_giv[thread_num], dt);
                 BL_PROFILE_VAR_STOP(blp_ppc_pp);
 
@@ -1405,7 +1366,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 } else {
                     ion_lev = nullptr;
                 }
-                
+
                 // Deposit inside domains
                 DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, &jx, &jy, &jz,
                                0, np_current, thread_num,
@@ -1425,7 +1386,7 @@ PhysicalParticleContainer::Evolve (int lev,
                 pti.SetPosition(m_xp[thread_num], m_yp[thread_num], m_zp[thread_num]);
                 BL_PROFILE_VAR_STOP(blp_copy);
             }
-            
+
             if (rho) {
                 // Deposit charge after particle push, in component 1 of MultiFab rho.
                 int* AMREX_RESTRICT ion_lev;
@@ -1494,7 +1455,7 @@ PhysicalParticleContainer::SplitParticles(int lev)
         for(int i=0; i<np; i++){
             auto& p = particles[i];
             if (p.id() == DoSplitParticleID){
-                // If particle is tagged, split it and put the 
+                // If particle is tagged, split it and put the
                 // split particles in local arrays psplit_x etc.
                 np_split_to_add += np_split;
 #if (AMREX_SPACEDIM==2)
@@ -1591,11 +1552,11 @@ PhysicalParticleContainer::SplitParticles(int lev)
     }
 	// Add local arrays psplit_x etc. to the temporary
 	// particle container pctmp_split. Split particles
-	// are tagged with p.id()=NoSplitParticleID so that 
+	// are tagged with p.id()=NoSplitParticleID so that
 	// they are not re-split when entering a higher level
 	// AddNParticles calls Redistribute, so that particles
 	// in pctmp_split are in the proper grids and tiles
-	pctmp_split.AddNParticles(lev, 
+	pctmp_split.AddNParticles(lev,
                               np_split_to_add,
                               psplit_x.dataPtr(),
                               psplit_y.dataPtr(),
@@ -1647,61 +1608,61 @@ PhysicalParticleContainer::PushPX(WarpXParIter& pti,
     if (do_field_ionization){
         ion_lev = pti.GetiAttribs(particle_icomps["ionization_level"]).dataPtr();
     }
-    
+
     // Loop over the particles and update their momentum
     const Real q = this->charge;
     const Real m = this-> mass;
     if (WarpX::particle_pusher_algo == ParticlePusherAlgo::Boris){
-        amrex::ParallelFor( 
+        amrex::ParallelFor(
             pti.numParticles(),
             [=] AMREX_GPU_DEVICE (long i) {
                 auto& p = particles[i];
-                if (p.id() == 11264000){
+                if (false){
                     //amrex::Print() << " pid " << p.id() << "\n";
                     //amrex::Print() << " before mom boris\n";
-                    //amrex::Print() << " position " << x[i] << " "; 
+                    //amrex::Print() << " position " << x[i] << " ";
                     //amrex::Print() << y[i] << " " << z[i] << "\n";
                     //    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                     //    // Compute inverse Lorentz factor
                     //    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
-                    //amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ; 
+                    //amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
                     //amrex::Print() << " " << uz[i]*inv_gamma << "\n";
-                    amrex::Print() << " EF " << Ex[i]; 
+                    amrex::Print() << " EF " << Ex[i];
                     amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
-                    amrex::Print() << " Bfield " << Bx[i]; 
+                    amrex::Print() << " Bfield " << Bx[i];
                     amrex::Print() << " " << By[i] << " " << Bz[i] << "\n";
                 }
                 Real qp = q;
                 if (ion_lev){ qp *= ion_lev[i]; }
                 UpdateMomentumBoris( ux[i], uy[i], uz[i], gi[i],
                       Ex[i], Ey[i], Ez[i], Bx[i], By[i], Bz[i], q, m, dt);
-                if (p.id() == 11264000){
+                if (false){
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
                     amrex::Print() << " *****after mom boris pushpx****\n";
-                    //amrex::Print() << " position " << x[i] << " "; 
+                    //amrex::Print() << " position " << x[i] << " ";
                     //amrex::Print() << y[i] << " " << z[i] << "\n";
-                    amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ; 
+                    amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
                     amrex::Print() << " " << uz[i]*inv_gamma << "\n";
-                    //amrex::Print() << " EF " << Ex[i]; 
+                    //amrex::Print() << " EF " << Ex[i];
                     //amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
                 }
                 UpdatePosition( x[i], y[i], z[i],
                       ux[i], uy[i], uz[i], dt );
-                if (p.id() == 11264000){
+                if (false){
                     amrex::Print() << " ***** after update pos pushpx *****\n";
-                    amrex::Print() << " position " << x[i] << " "; 
+                    amrex::Print() << " position " << x[i] << " ";
                     amrex::Print() << y[i] << " " << z[i] << "\n";
                     //    constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                     //    // Compute inverse Lorentz factor
                     //    const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux[i]*ux[i] + uy[i]*uy[i] + uz[i]*uz[i])*inv_c2);
-                    //amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ; 
+                    //amrex::Print() << " vel " << ux[i]*inv_gamma << " " << uy[i]*inv_gamma ;
                     //amrex::Print() << " " << uz[i]*inv_gamma << "\n";
-                    //amrex::Print() << " EF " << Ex[i]; 
+                    //amrex::Print() << " EF " << Ex[i];
                     //amrex::Print() << " " << Ey[i] << " " << Ez[i] << "\n";
                 }
             }
@@ -1744,7 +1705,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
         int thread_num = omp_get_thread_num();
 #else
         int thread_num = 0;
-#endif      
+#endif
         for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             const Box& box = pti.validbox();
@@ -1760,7 +1721,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             auto& wp = attribs[PIdx::w];
 
             const long np = pti.numParticles();
-            
+
             //
             // copy data from particle container to temp arrays
             //
@@ -1784,7 +1745,6 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             m_giv[thread_num].resize(np);
 
             // For Pulsar //
-            // spin particles 
             // find center of pulsar //
             auto& particles = pti.GetArrayOfStructs();
             const Real xc = (Geom(0).ProbHi(0) - Geom(0).ProbLo(0))/2.0;
@@ -1804,59 +1764,23 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             Real* const AMREX_RESTRICT Bypp_pm = Byp.dataPtr();
             Real* const AMREX_RESTRICT Bzpp_pm = Bzp.dataPtr();
             Real* const AMREX_RESTRICT wp_pm = wp.dataPtr();
-            Real t = WarpX::GetInstance().gett_new(lev);
-            int istep = t/dt;
             const Real q_pm = this->charge;
             const Real m_pm = this-> mass;
 
-            amrex::ParallelFor(pti.numParticles(), 
+            amrex::ParallelFor(pti.numParticles(),
                  [=] AMREX_GPU_DEVICE (long i) {
                      auto& p = particles[i];
-                     if (p.id() == 11264000){
-                        const amrex::Real r = std::sqrt( (xp_pm[i]-xc)*(xp_pm[i]-xc) + 
-                                                         (yp_pm[i]-yc)*(yp_pm[i]-yc) + 
-                                                         (zp_pm[i]-zc)*(zp_pm[i]-zc));
-                        const amrex::Real phi = std::atan2((yp_pm[i]-yc),(xp_pm[i]-xc));
-                        amrex::Real theta = 0.0;
-                        if (r>0) {
-                           theta = std::acos( (zp_pm[i]-zc)/r );
-                        }
-                        amrex::Real c_theta = std::cos(theta);
-                        amrex::Real s_theta = std::sin(theta);
-                        amrex::Real c_phi = std::cos(phi);
-                        amrex::Real s_phi = std::sin(phi);
-                        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-                         amrex::Print() << " ***before ext force t = " << t << " istep " << istep <<" *** \n" ;
-                         amrex::Print() << " r " << r << " dt " << dt <<  "\n"; 
-                         amrex::Print() << " theta " << theta << " phi " << phi << "\n";
 
-                        // Compute inverse Lorentz factor
-                        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         const amrex::Real omega_star = 11250;
-                         amrex::Print() << " speed " << std::sqrt(ux_pm[i]*ux_pm[i]*inv_gamma*inv_gamma + uy_pm[i]*uy_pm[i]*inv_gamma*inv_gamma + uz_pm[i]*uz_pm[i]*inv_gamma*inv_gamma) << " romega " << r*s_theta*omega_star << "\n";;
-                     }
                      ApplyExternalForce(xp_pm[i],yp_pm[i],zp_pm[i],
                          ux_pm[i],uy_pm[i],uz_pm[i],Expp_pm[i],Eypp_pm[i],
                          Ezpp_pm[i],Bxpp_pm[i],Bypp_pm[i],Bzpp_pm[i],
-                         xc,yc,zc,q_pm,m_pm,dt,istep,wp_pm[i]);               
-                     if (p.id() == 11264000){
-                        constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
-
-                        // Compute inverse Lorentz factor
-                        const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " ***** after ext *****\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;  
-                         amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;  
-                         amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
-                         amrex::Print() << " q_pm " << q_pm << "\n";
-                     }
+                         xc,yc,zc,q_pm,m_pm,wp_pm[i],p.id());
             });
- 
+
 
             int e_is_nodal = Ex.is_nodal() and Ey.is_nodal() and Ez.is_nodal();
             FieldGather(pti, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                        &exfab, &eyfab, &ezfab, &bxfab, &byfab, &bzfab, 
+                        &exfab, &eyfab, &ezfab, &bxfab, &byfab, &bzfab,
                         Ex.nGrow(), e_is_nodal, 0, np, thread_num, lev, lev);
             // This wraps the momentum advance so that inheritors can modify the call.
             // Extract pointers to the different particle quantities
@@ -1879,22 +1803,22 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 amrex::ParallelFor( pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
                      auto& p = particless[i];
-                     if (p.id() == 11264000){
+                     if (false){
                          //amrex::Print() << " before mom boris\n";
-                         //amrex::Print() << " position " << xp_pm[i] << " "; 
+                         //amrex::Print() << " position " << xp_pm[i] << " ";
                          //amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                          //constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         //// Compute inverse Lorentz factor
                         //const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         //amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ; 
+                         //amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
                          //amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;  
+                         amrex::Print() << " Efield " << Expp_pm[i] ;
                          amrex::Print() << " " << Eypp[i] << " " << Ezpp[i] << "\n";
-                         //amrex::Print() << " Bfield " << Bxpp[i] ;  
+                         //amrex::Print() << " Bfield " << Bxpp[i] ;
                          //amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
                          //amrex::Print() << " q_pm " << q << "\n";
-                         amrex::Print() << " Bfield " << Bxpp[i]; 
+                         amrex::Print() << " Bfield " << Bxpp[i];
                          amrex::Print() << " " << Bypp[i] << " " << Bzpp[i] << "\n";
 
                          const amrex::Real econst = 0.5*q*dt/m;
@@ -1903,7 +1827,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                          amrex::Real ux = 0.0;  ux += econst*Expp_pm[i];
                          amrex::Real uy = 0.0;  uy += econst*Eypp_pm[i];
                          amrex::Real uz = 0.0;  uz += econst*Ezpp_pm[i];
-                         amrex::Print() << " my vel 1 " << ux << " " << uy << " " << uz << "\n"; 
+                         amrex::Print() << " my vel 1 " << ux << " " << uy << " " << uz << "\n";
                          // Compute temporary gamma factor
                          constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
                          const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
@@ -1926,7 +1850,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                          ux += uy_p*sz - uz_p*sy;
                          uy += uz_p*sx - ux_p*sz;
                          uz += ux_p*sy - uy_p*sx;
-                         amrex::Print() << " my vel 2 " << ux << " " << uy << " " << uz << "\n"; 
+                         amrex::Print() << " my vel 2 " << ux << " " << uy << " " << uz << "\n";
                          amrex::Print() << " epush  " << econst*Expp_pm[i]  ;
                          amrex::Print() << " " << econst*Eypp_pm[i] << " ";
                          amrex::Print() << " " << econst*Ezpp_pm[i] << "\n";
@@ -1934,26 +1858,26 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                          ux += econst*Expp_pm[i];
                          uy += econst*Eypp_pm[i];
                          uz += econst*Ezpp_pm[i];
-                         amrex::Print() << " my vel 3 " << ux << " " << uy << " " << uz << "\n"; 
+                         amrex::Print() << " my vel 3 " << ux << " " << uy << " " << uz << "\n";
                          amrex::Real tgaminv = 1./std::sqrt(1. + (ux*ux + uy*uy + uz*uz)*inv_c2);
-                         amrex::Print() << " my vel  " << ux << " " << uy << " " << uz << "\n"; 
+                         amrex::Print() << " my vel  " << ux << " " << uy << " " << uz << "\n";
                      }
                         UpdateMomentumBoris( ux[i], uy[i], uz[i], gi[i],
                               Expp[i], Eypp[i], Ezpp[i], Bxpp[i], Bypp[i], Bzpp[i], q, m, dt);
 
-                     if (p.id() == 11264000){
+                     if (false){
                          //amrex::Print() << " after mom boris\n";
-                         //amrex::Print() << " position " << xp_pm[i] << " "; 
+                         //amrex::Print() << " position " << xp_pm[i] << " ";
                          //amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ; 
+                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
                          amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         //amrex::Print() << " Efield " << Expp_pm[i] ;  
+                         //amrex::Print() << " Efield " << Expp_pm[i] ;
                          //amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         //amrex::Print() << " Bfield " << Bxpp_pm[i] ;  
+                         //amrex::Print() << " Bfield " << Bxpp_pm[i] ;
                          //amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
                          //amrex::Print() << " q_pm " << q << "\n";
                      }
@@ -1964,36 +1888,36 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 amrex::ParallelFor( pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
                      auto& p = particles[i];
-                     if (p.id() == 11264000){
+                     if (false){
                          amrex::Print() << " before mom vay\n";
-                         amrex::Print() << " position " << xp_pm[i] << " "; 
+                         amrex::Print() << " position " << xp_pm[i] << " ";
                          amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ; 
+                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
                          amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;  
+                         amrex::Print() << " Efield " << Expp_pm[i] ;
                          amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;  
+                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;
                          amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
                      }
                         UpdateMomentumVay( ux[i], uy[i], uz[i], gi[i],
                               Expp[i], Eypp[i], Ezpp[i], Bxpp[i], Bypp[i], Bzpp[i], q, m, dt);
-                     if (p.id() == 11264000){
+                     if (false){
                          amrex::Print() << " before mom vay\n";
-                         amrex::Print() << " position " << xp_pm[i] << " "; 
+                         amrex::Print() << " position " << xp_pm[i] << " ";
                          amrex::Print() << yp_pm[i] << " " << zp_pm[i] << "\n";
                         constexpr amrex::Real inv_c2 = 1./(PhysConst::c*PhysConst::c);
 
                         // Compute inverse Lorentz factor
                         const amrex::Real inv_gamma = 1./std::sqrt(1. + (ux_pm[i]*ux_pm[i] + uy_pm[i]*uy_pm[i] + uz_pm[i]*uz_pm[i])*inv_c2);
-                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ; 
+                         amrex::Print() << " vel " << ux_pm[i]*inv_gamma << " " << uy_pm[i]*inv_gamma ;
                          amrex::Print() << " " << uz_pm[i]*inv_gamma << "\n";
-                         amrex::Print() << " Efield " << Expp_pm[i] ;  
+                         amrex::Print() << " Efield " << Expp_pm[i] ;
                          amrex::Print() << " " << Eypp_pm[i] << " " << Ezpp_pm[i] << "\n";
-                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;  
+                         amrex::Print() << " Bfield " << Bxpp_pm[i] ;
                          amrex::Print() << " " << Bypp_pm[i] << " " << Bzpp_pm[i] << "\n";
                      }
                     }
@@ -2012,7 +1936,7 @@ void PhysicalParticleContainer::copy_attribs(WarpXParIter& pti,const Real* xp,
     Real* AMREX_RESTRICT uxp = attribs[PIdx::ux].dataPtr();
     Real* AMREX_RESTRICT uyp = attribs[PIdx::uy].dataPtr();
     Real* AMREX_RESTRICT uzp = attribs[PIdx::uz].dataPtr();
-    
+
     const auto np = pti.numParticles();
     const auto lev = pti.GetLevel();
     const auto index = pti.GetPairIndex();
@@ -2028,7 +1952,7 @@ void PhysicalParticleContainer::copy_attribs(WarpXParIter& pti,const Real* xp,
                      xpold[i]=xp[i];
                      ypold[i]=yp[i];
                      zpold[i]=zp[i];
-            
+
                      uxpold[i]=uxp[i];
                      uypold[i]=uyp[i];
                      uzpold[i]=uzp[i];
@@ -2068,7 +1992,7 @@ void PhysicalParticleContainer::GetParticleSlice(const int direction, const Real
     slice_box.setHi(direction, z_max);
 
     diagnostic_particles.resize(finestLevel()+1);
-    
+
     for (int lev = 0; lev < nlevs; ++lev) {
 
         const Real* dx  = Geom(lev).CellSize();
@@ -2115,7 +2039,7 @@ void PhysicalParticleContainer::GetParticleSlice(const int direction, const Real
                 auto& uzp_old = tmp_particle_data[lev][index][TmpIdx::uzold];
 
                 const long np = pti.numParticles();
-                
+
                 Real uzfrm = -WarpX::gamma_boost*WarpX::beta_boost*PhysConst::c;
                 Real inv_c2 = 1.0/PhysConst::c/PhysConst::c;
 
@@ -2150,7 +2074,7 @@ void PhysicalParticleContainer::GetParticleSlice(const int direction, const Real
                     Real uzp = uz_old_p  *weight_old + uz_new_p  *weight_new;
 
                     diagnostic_particles[lev][index].GetRealData(DiagIdx::w).push_back(wp[i]);
-                    
+
                     diagnostic_particles[lev][index].GetRealData(DiagIdx::x).push_back(xp);
                     diagnostic_particles[lev][index].GetRealData(DiagIdx::y).push_back(yp);
                     diagnostic_particles[lev][index].GetRealData(DiagIdx::z).push_back(zp);
@@ -2175,7 +2099,7 @@ PhysicalParticleContainer::ContinuousInjection(const RealBox& injection_box)
     AddPlasma(lev, injection_box);
 }
 
-/* \brief Gather fields from FArrayBox exfab, eyfab, ezfab, bxfab, byfab, 
+/* \brief Gather fields from FArrayBox exfab, eyfab, ezfab, bxfab, byfab,
  * bzfab into arrays of fields on particles Exp, Eyp, Ezp, Bxp, Byp, Bzp.
  * \param Exp-Bzp: fields on particles.
  * \param exfab-bzfab: FAB of electric and magnetic fields for particles in pti
@@ -2185,7 +2109,7 @@ PhysicalParticleContainer::ContinuousInjection(const RealBox& injection_box)
  * \param np_to_gather: number of particles onto which fields are gathered
  * \param thread_num: if using OpenMP, thread number
  * \param lev: level on which particles are located
- * \param gather_lev: level from which particles gather fields (lev-1) for 
+ * \param gather_lev: level from which particles gather fields (lev-1) for
           particles in buffers.
  */
 void
@@ -2212,14 +2136,14 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE((gather_lev==(lev-1)) ||
                                      (gather_lev==(lev  )),
                                      "Gather buffers only work for lev-1");
-    
+
     // If no particles, do not do anything
     if (np_to_gather == 0) return;
     // Get cell size on gather_lev
     const std::array<Real,3>& dx = WarpX::CellSize(std::max(gather_lev,0));
     // Set staggering shift depending on e_is_nodal
     const Real stagger_shift = e_is_nodal ? 0.0 : 0.5;
-    
+
     // Get box from which field is gathered.
     // If not gathering from the finest level, the box is coarsened.
     Box box;
@@ -2229,26 +2153,26 @@ PhysicalParticleContainer::FieldGather (WarpXParIter& pti,
         const IntVect& ref_ratio = WarpX::RefRatio(gather_lev);
         box = amrex::coarsen(pti.tilebox(),ref_ratio);
     }
-    
+
     // Add guard cells to the box.
     box.grow(ngE);
-    
+
     const Array4<const Real>& ex_arr = exfab->array();
     const Array4<const Real>& ey_arr = eyfab->array();
     const Array4<const Real>& ez_arr = ezfab->array();
     const Array4<const Real>& bx_arr = bxfab->array();
     const Array4<const Real>& by_arr = byfab->array();
     const Array4<const Real>& bz_arr = bzfab->array();
-    
+
     const Real * const AMREX_RESTRICT xp = m_xp[thread_num].dataPtr() + offset;
     const Real * const AMREX_RESTRICT zp = m_zp[thread_num].dataPtr() + offset;
     const Real * const AMREX_RESTRICT yp = m_yp[thread_num].dataPtr() + offset;
-    
+
     // Lower corner of tile box physical domain
     const std::array<Real, 3>& xyzmin = WarpX::LowerCorner(box, gather_lev);
-    
+
     const Dim3 lo = lbound(box);
-    
+
     // Depending on l_lower_in_v and WarpX::nox, call
     // different versions of template function doGatherShapeN
     if (WarpX::l_lower_order_in_v){
@@ -2331,10 +2255,10 @@ void PhysicalParticleContainer::InitIonizationModule ()
     }
     // Compute ADK prefactors (See Chen, JCP 236 (2013), equation (2))
     // For now, we assume l=0 and m=0.
-    // The approximate expressions are used, 
+    // The approximate expressions are used,
     // without Gamma function
     Real wa = std::pow(PhysConst::alpha,3) * PhysConst::c / PhysConst::r_e;
-    Real Ea = PhysConst::m_e * PhysConst::c*PhysConst::c /PhysConst::q_e * 
+    Real Ea = PhysConst::m_e * PhysConst::c*PhysConst::c /PhysConst::q_e *
         std::pow(PhysConst::alpha,4)/PhysConst::r_e;
     Real UH = table_ionization_energies[0];
     Real l_eff = std::sqrt(UH/ionization_energies[0]) - 1.;
@@ -2349,18 +2273,18 @@ void PhysicalParticleContainer::InitIonizationModule ()
         Real C2 = std::pow(2,2*n_eff)/(n_eff*tgamma(n_eff+l_eff+1)*tgamma(n_eff-l_eff));
         adk_power[i] = -(2*n_eff - 1);
         Real Uion = ionization_energies[i];
-        adk_prefactor[i] = dt * wa * C2 * ( Uion/(2*UH) ) 
+        adk_prefactor[i] = dt * wa * C2 * ( Uion/(2*UH) )
             * std::pow(2*std::pow((Uion/UH),3./2)*Ea,2*n_eff - 1);
         adk_exp_prefactor[i] = -2./3 * std::pow( Uion/UH,3./2) * Ea;
     }
 }
 
 /* \brief create mask of ionized particles (1 if ionized, 0 otherwise)
- * 
+ *
  * \param mfi: tile or grid
  * \param lev: MR level
  * \param ionization_mask: Array with as many elements as particles in mfi.
- * This function initialized the array, and set each element to 1 or 0 
+ * This function initialized the array, and set each element to 1 or 0
  * depending on whether the particle is ionized or not.
  */
 void
@@ -2406,7 +2330,7 @@ PhysicalParticleContainer::buildIonizationMask (const amrex::MFIter& mfi, const 
 
     // Loop over all particles in grid/tile. If ionized, set mask to 1
     // and increment ionization level.
-    ParallelFor( 
+    ParallelFor(
         np,
         [=] AMREX_GPU_DEVICE (long i) {
             // Get index of ionization_level

--- a/Source/Particles/PulsarParameters.H
+++ b/Source/Particles/PulsarParameters.H
@@ -1,0 +1,26 @@
+#ifndef PULSAR_PARAMETERS_H
+#define PULSAR_PARAMETERS_H
+
+#include <AMReX_REAL.H>
+#include <AMReX_GpuQualifiers.H>
+
+namespace PulsarParm
+{
+    extern AMREX_GPU_DEVICE_MANAGED int use_conductor_E;
+    extern AMREX_GPU_DEVICE_MANAGED int use_external_E;
+    extern AMREX_GPU_DEVICE_MANAGED int include_external_monopole_E;
+    extern AMREX_GPU_DEVICE_MANAGED int use_drag_force;
+    extern AMREX_GPU_DEVICE_MANAGED amrex::Real drag_force_tau;
+
+    extern AMREX_GPU_DEVICE_MANAGED int B_omega_alignment;
+    extern AMREX_GPU_DEVICE_MANAGED amrex::Real omega_star;
+    extern AMREX_GPU_DEVICE_MANAGED amrex::Real R_star;
+    extern AMREX_GPU_DEVICE_MANAGED amrex::Real B_star;
+
+    extern AMREX_GPU_DEVICE_MANAGED int verbose_external;
+    extern AMREX_GPU_DEVICE_MANAGED long pid_verbose_external;
+
+    void Initialize();
+}
+
+#endif

--- a/Source/Particles/PulsarParameters.H
+++ b/Source/Particles/PulsarParameters.H
@@ -17,8 +17,8 @@ namespace PulsarParm
     extern AMREX_GPU_DEVICE_MANAGED amrex::Real R_star;
     extern AMREX_GPU_DEVICE_MANAGED amrex::Real B_star;
 
-    extern AMREX_GPU_DEVICE_MANAGED int verbose_external;
-    extern AMREX_GPU_DEVICE_MANAGED long pid_verbose_external;
+    extern AMREX_GPU_DEVICE_MANAGED int verbose;
+    extern AMREX_GPU_DEVICE_MANAGED long pid_verbose;
 
     void Initialize();
 }

--- a/Source/Particles/PulsarParameters.cpp
+++ b/Source/Particles/PulsarParameters.cpp
@@ -15,8 +15,8 @@ namespace PulsarParm
     AMREX_GPU_DEVICE_MANAGED amrex::Real R_star = 10.e3; // radius of NS (m)
     AMREX_GPU_DEVICE_MANAGED amrex::Real B_star = 1.e8; // magnetic field of NS (T)
 
-    AMREX_GPU_DEVICE_MANAGED int verbose_external = 0; // [0/1]: turn on verbosity for external force
-    AMREX_GPU_DEVICE_MANAGED long pid_verbose_external = 0; // print particle properties for this particle ID if verbose_external = 1.
+    AMREX_GPU_DEVICE_MANAGED int verbose = 0; // [0/1]: turn on verbosity for external force
+    AMREX_GPU_DEVICE_MANAGED long pid_verbose = 0; // print particle properties for this particle ID if verbose = 1.
 
     void Initialize()
     {
@@ -33,7 +33,7 @@ namespace PulsarParm
         pp.query("R_star", R_star);
         pp.query("B_star", B_star);
 
-        pp.query("verbose_external", verbose_external);
-        pp.query("pid_verbose_external", pid_verbose_external);
+        pp.query("verbose", verbose);
+        pp.query("pid_verbose", pid_verbose);
     }
 }

--- a/Source/Particles/PulsarParameters.cpp
+++ b/Source/Particles/PulsarParameters.cpp
@@ -1,0 +1,39 @@
+#include <PulsarParameters.H>
+#include <AMReX_ParmParse.H>
+
+namespace PulsarParm
+{
+    AMREX_GPU_DEVICE_MANAGED int use_conductor_E = 0; // [0/1]: set E = -(omega*R)[cross]B inside NS
+    AMREX_GPU_DEVICE_MANAGED int use_external_E = 0;  // [0/1]: use external analytic E field
+    AMREX_GPU_DEVICE_MANAGED int include_external_monopole_E = 0; // [0/1]: turn off/on external E monopole term
+    AMREX_GPU_DEVICE_MANAGED int use_drag_force = 1;  // [0/1]: apply drag force within the NS
+    AMREX_GPU_DEVICE_MANAGED amrex::Real drag_force_tau = 1.0e-8; // drag force timescale (seconds)
+
+    AMREX_GPU_DEVICE_MANAGED int B_omega_alignment = 1; // [1/-1]: sign of B[dot]omega
+
+    AMREX_GPU_DEVICE_MANAGED amrex::Real omega_star = 1.e4; // angular velocity of NS (rad/s)
+    AMREX_GPU_DEVICE_MANAGED amrex::Real R_star = 10.e3; // radius of NS (m)
+    AMREX_GPU_DEVICE_MANAGED amrex::Real B_star = 1.e8; // magnetic field of NS (T)
+
+    AMREX_GPU_DEVICE_MANAGED int verbose_external = 0; // [0/1]: turn on verbosity for external force
+    AMREX_GPU_DEVICE_MANAGED long pid_verbose_external = 0; // print particle properties for this particle ID if verbose_external = 1.
+
+    void Initialize()
+    {
+        amrex::ParmParse pp("pulsar");
+
+        pp.query("use_conductor_E", use_conductor_E);
+        pp.query("use_external_E", use_external_E);
+        pp.query("include_external_monopole_E", include_external_monopole_E);
+        pp.query("use_drag_force", use_drag_force);
+        pp.query("drag_force_tau", drag_force_tau);
+
+        pp.query("B_omega_alignment", B_omega_alignment);
+        pp.query("omega_star", omega_star);
+        pp.query("R_star", R_star);
+        pp.query("B_star", B_star);
+
+        pp.query("verbose_external", verbose_external);
+        pp.query("pid_verbose_external", pid_verbose_external);
+    }
+}

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -24,6 +24,8 @@
 #include <AMReX_AmrMeshInSituBridge.H>
 #endif
 
+#include <PulsarParameters.H>
+
 using namespace amrex;
 
 Vector<Real> WarpX::B_external(3, 0.0);
@@ -590,6 +592,8 @@ WarpX::ReadParameters ()
 
     }
 
+    // initialize Pulsar problem parameters //
+    PulsarParm::Initialize();
 }
 
 // This is a virtual function.

--- a/Tools/pulsar_vis/mkmovie.sh
+++ b/Tools/pulsar_vis/mkmovie.sh
@@ -4,6 +4,10 @@ parallel --keep-order --tag "python3 pulsar_plot.py {} $@" ::: `ls -d plt?????`
 
 echo "Finished plotting"
 
-parallel --keep-order --tag "python3 ffmpeg_make_mp4 plt*{}.png -s -ifps 10 -ofps 30 -name {} > /dev/null 2>&1" ::: `cat plot_types.txt`
+for vars in $(cat plot_types.txt);
+    do
+        echo $vars;
+        python3 ffmpeg_make_mp4 plt*$vars.png -s -ifps 10 -ofps 30 -name $vars;
+    done
 
 echo "Finished making movies"


### PR DESCRIPTION
This moves the hard-coded parameters for the pulsar setup into a `PulsarParm` namespace so we can set the radius, omega, B, etc. at runtime.

Also this separates the different external fields/drag force into different options that are enabled by setting flags in the inputs so we can look at combinations of these more easily.

For debugging prints, we have a `PulsarParm::verbose` flag that turns them on/off and we can set what particle we want to print values for with `PulsarParm::pid_verbose`.

There is an example inputs file that uses all these inputs in `Examples/Physics_applications/pulsar/inputs.corotating.3d.PM`.