### PR TITLE
evolveM_ifdefmag

### DIFF
--- a/Docs/source/building/building.rst
+++ b/Docs/source/building/building.rst
@@ -51,6 +51,7 @@ options are:
     * ``COMP=gcc`` or ``intel``: Compiler.
     * ``USE_MPI=TRUE`` or ``FALSE``: Whether to compile with MPI support.
     * ``USE_OMP=TRUE`` or ``FALSE``: Whether to compile with OpenMP support.
+    * ``USE_LLG=TRUE`` or ``FALSE``: Whether to compile with Landau-Lifshitz-Gilbert (LLG) model to compute magnetization.
 
 For a description of these different options, see the `corresponding page <https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html>`__ in the AMReX documentation.
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,6 +36,7 @@ WarpxBinDir = Bin
 USE_PSATD = FALSE
 USE_PSATD_PICSAR = FALSE
 USE_RZ = FALSE
+USE_LLG = FALSE
 
 WARPX_HOME := .
 include $(WARPX_HOME)/Source/Make.WarpX

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -439,9 +439,8 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 1), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "Bz" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 2), lev, m_crse_ratio);
-        }
 #ifdef WARPX_MAG_LLG
-    else if ( m_varnames[comp] == "Mx_xface" ){
+        } else if ( m_varnames[comp] == "Mx_xface" ){
             // For the magnetization variables (e.g., Mx_xface) we have to pass in an additional integer stating which variable from the Mfield MultiFab
             // will get averaged/interpolated to the ce1ll-centered plotfile MultiFab.  This is the final integer in the calling sequence.
             // Unlike the B field, for M we store all 3 components of the vector M at each face, where 0=Mx, 1=My, 2=Mz
@@ -463,9 +462,8 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 1), lev, m_crse_ratio, true, 1, 2);
         } else if ( m_varnames[comp] == "Mz_zface" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 2), lev, m_crse_ratio, true, 1, 2);
-        }
 #endif
-    else if ( m_varnames[comp] == "jx" ){
+        } else if ( m_varnames[comp] == "jx" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 0), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "jy" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 1), lev, m_crse_ratio);

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -439,8 +439,8 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 1), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "Bz" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 2), lev, m_crse_ratio);
-        } 
-#ifdef WARPX_MAG_LLG    
+        }
+#ifdef WARPX_MAG_LLG
     else if ( m_varnames[comp] == "Mx_xface" ){
             // For the magnetization variables (e.g., Mx_xface) we have to pass in an additional integer stating which variable from the Mfield MultiFab
             // will get averaged/interpolated to the ce1ll-centered plotfile MultiFab.  This is the final integer in the calling sequence.
@@ -463,8 +463,8 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 1), lev, m_crse_ratio, true, 1, 2);
         } else if ( m_varnames[comp] == "Mz_zface" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 2), lev, m_crse_ratio, true, 1, 2);
-        }     
-#endif    
+        }
+#endif
     else if ( m_varnames[comp] == "jx" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 0), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "jy" ){

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -439,7 +439,9 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 1), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "Bz" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 2), lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "Mx_xface" ){
+        } 
+#ifdef WARPX_MAG_LLG	
+	else if ( m_varnames[comp] == "Mx_xface" ){
             // For the magnetization variables (e.g., Mx_xface) we have to pass in an additional integer stating which variable from the Mfield MultiFab
             // will get averaged/interpolated to the ce1ll-centered plotfile MultiFab.  This is the final integer in the calling sequence.
             // Unlike the B field, for M we store all 3 components of the vector M at each face, where 0=Mx, 1=My, 2=Mz
@@ -461,7 +463,9 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 1), lev, m_crse_ratio, true, 1, 2);
         } else if ( m_varnames[comp] == "Mz_zface" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 2), lev, m_crse_ratio, true, 1, 2);
-        } else if ( m_varnames[comp] == "jx" ){
+        } 	
+#endif	
+	else if ( m_varnames[comp] == "jx" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 0), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "jy" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 1), lev, m_crse_ratio);

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -440,8 +440,8 @@ Diagnostics::InitializeFieldFunctors (int lev)
         } else if ( m_varnames[comp] == "Bz" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Bfield_aux(lev, 2), lev, m_crse_ratio);
         } 
-#ifdef WARPX_MAG_LLG	
-	else if ( m_varnames[comp] == "Mx_xface" ){
+#ifdef WARPX_MAG_LLG    
+    else if ( m_varnames[comp] == "Mx_xface" ){
             // For the magnetization variables (e.g., Mx_xface) we have to pass in an additional integer stating which variable from the Mfield MultiFab
             // will get averaged/interpolated to the ce1ll-centered plotfile MultiFab.  This is the final integer in the calling sequence.
             // Unlike the B field, for M we store all 3 components of the vector M at each face, where 0=Mx, 1=My, 2=Mz
@@ -463,9 +463,9 @@ Diagnostics::InitializeFieldFunctors (int lev)
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 1), lev, m_crse_ratio, true, 1, 2);
         } else if ( m_varnames[comp] == "Mz_zface" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_Mfield_aux(lev, 2), lev, m_crse_ratio, true, 1, 2);
-        } 	
-#endif	
-	else if ( m_varnames[comp] == "jx" ){
+        }     
+#endif    
+    else if ( m_varnames[comp] == "jx" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 0), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "jy" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.get_pointer_current_fp(lev, 1), lev, m_crse_ratio);

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -163,9 +163,9 @@ WarpX::InitFromCheckpoint ()
             Efield_fp[lev][i]->setVal(0.0);
             Bfield_fp[lev][i]->setVal(0.0);
 #ifdef WARPX_MAG_LLG
-        Mfield_fp[lev][i]->setVal(0.0);
+            Mfield_fp[lev][i]->setVal(0.0);
 #endif
-    }
+        }
 
         if (lev > 0) {
             for (int i = 0; i < 3; ++i) {
@@ -180,7 +180,7 @@ WarpX::InitFromCheckpoint ()
 #ifdef WARPX_MAG_LLG
                 Mfield_cp[lev][i]->setVal(0.0);
 #endif
-        }
+            }
         }
 
         VisMF::Read(*Efield_fp[lev][0],

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -162,20 +162,25 @@ WarpX::InitFromCheckpoint ()
             current_fp[lev][i]->setVal(0.0);
             Efield_fp[lev][i]->setVal(0.0);
             Bfield_fp[lev][i]->setVal(0.0);
-            Mfield_fp[lev][i]->setVal(0.0);
-        }
+#ifdef WARPX_MAG_LLG
+	    Mfield_fp[lev][i]->setVal(0.0);
+#endif
+	}
 
         if (lev > 0) {
             for (int i = 0; i < 3; ++i) {
                 Efield_aux[lev][i]->setVal(0.0);
                 Bfield_aux[lev][i]->setVal(0.0);
+#ifdef WARPX_MAG_LLG
                 Mfield_aux[lev][i]->setVal(0.0);
-
+#endif
                 current_cp[lev][i]->setVal(0.0);
                 Efield_cp[lev][i]->setVal(0.0);
                 Bfield_cp[lev][i]->setVal(0.0);
+#ifdef WARPX_MAG_LLG
                 Mfield_cp[lev][i]->setVal(0.0);
-            }
+#endif
+	    }
         }
 
         VisMF::Read(*Efield_fp[lev][0],
@@ -192,12 +197,14 @@ WarpX::InitFromCheckpoint ()
         VisMF::Read(*Bfield_fp[lev][2],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_fp"));
 
+#ifdef WARPX_MAG_LLG
         VisMF::Read(*Mfield_fp[lev][0],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mx_fp"));
         VisMF::Read(*Mfield_fp[lev][1],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "My_fp"));
         VisMF::Read(*Mfield_fp[lev][2],
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mz_fp"));
+#endif
 
         if (is_synchronized) {
             VisMF::Read(*current_fp[lev][0],
@@ -224,12 +231,14 @@ WarpX::InitFromCheckpoint ()
             VisMF::Read(*Bfield_cp[lev][2],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_cp"));
 
+#ifdef WARPX_MAG_LLG
             VisMF::Read(*Mfield_cp[lev][0],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mx_cp"));
             VisMF::Read(*Mfield_cp[lev][1],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "My_cp"));
             VisMF::Read(*Mfield_cp[lev][2],
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Mz_cp"));
+#endif
 
             if (is_synchronized) {
                 VisMF::Read(*current_cp[lev][0],

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -163,9 +163,9 @@ WarpX::InitFromCheckpoint ()
             Efield_fp[lev][i]->setVal(0.0);
             Bfield_fp[lev][i]->setVal(0.0);
 #ifdef WARPX_MAG_LLG
-	    Mfield_fp[lev][i]->setVal(0.0);
+        Mfield_fp[lev][i]->setVal(0.0);
 #endif
-	}
+    }
 
         if (lev > 0) {
             for (int i = 0; i < 3; ++i) {
@@ -180,7 +180,7 @@ WarpX::InitFromCheckpoint ()
 #ifdef WARPX_MAG_LLG
                 Mfield_cp[lev][i]->setVal(0.0);
 #endif
-	    }
+        }
         }
 
         VisMF::Read(*Efield_fp[lev][0],

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -116,7 +116,7 @@ WarpX::Evolve (int numsteps)
             FillBoundaryB(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
 #ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
-#endif 
+#endif
          // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
             // Need to update Aux on lower levels, to interpolate to higher levels.
 #ifndef WARPX_USE_PSATD
@@ -362,7 +362,7 @@ WarpX::OneStep_nosub (Real cur_time)
 
 #ifdef WARPX_MAG_LLG
     FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
-#endif        
+#endif
     FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         if (WarpX::em_solver_medium == MediumForEM::Vacuum) {
             // vacuum medium
@@ -393,7 +393,7 @@ WarpX::OneStep_nosub (Real cur_time)
         if ( safe_guard_cells ){
 #ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-#endif            
+#endif
         FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
         }
 #endif

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -96,9 +96,9 @@ WarpX::Evolve (int numsteps)
             FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
             FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
 #ifdef WARPX_MAG_LLG
-	    FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+        FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
 #endif
-	    UpdateAuxilaryData();
+        UpdateAuxilaryData();
             // on first step, push p by -0.5*dt
             for (int lev = 0; lev <= finest_level; ++lev)
             {
@@ -117,7 +117,7 @@ WarpX::Evolve (int numsteps)
 #ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
 #endif 
- 	    // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
+         // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
             // Need to update Aux on lower levels, to interpolate to higher levels.
 #ifndef WARPX_USE_PSATD
             FillBoundaryAux(guard_cells.ng_UpdateAux);
@@ -356,14 +356,14 @@ WarpX::OneStep_nosub (Real cur_time)
         EvolveF(0.5*dt[0], DtType::FirstHalf);
         FillBoundaryF(guard_cells.ng_FieldSolverF);
 #ifdef WARPX_MAG_LLG
-	EvolveM(0.5*dt[0]); // we now have M^{n+1/2}
+    EvolveM(0.5*dt[0]); // we now have M^{n+1/2}
 #endif
         EvolveB(0.5*dt[0]); // We now have B^{n+1/2}
 
 #ifdef WARPX_MAG_LLG
-	FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+    FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
 #endif        
-	FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+    FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         if (WarpX::em_solver_medium == MediumForEM::Vacuum) {
             // vacuum medium
             EvolveE(dt[0]); // We now have E^{n+1}
@@ -377,7 +377,7 @@ WarpX::OneStep_nosub (Real cur_time)
         FillBoundaryE(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         EvolveF(0.5*dt[0], DtType::SecondHalf);
 #ifdef WARPX_MAG_LLG
-	EvolveM(0.5*dt[0]); // we now have M^{n+1}
+    EvolveM(0.5*dt[0]); // we now have M^{n+1}
 #endif
         EvolveB(0.5*dt[0]); // We now have B^{n+1}
         //why not implementing FillBoundary here? possibly: implemented in if{safe_guard_cells} Line 452
@@ -394,7 +394,7 @@ WarpX::OneStep_nosub (Real cur_time)
 #ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
 #endif            
-	    FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+        FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
         }
 #endif
     }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -96,9 +96,9 @@ WarpX::Evolve (int numsteps)
             FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
             FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
 #ifdef WARPX_MAG_LLG
-        FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+            FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
 #endif
-        UpdateAuxilaryData();
+            UpdateAuxilaryData();
             // on first step, push p by -0.5*dt
             for (int lev = 0; lev <= finest_level; ++lev)
             {
@@ -117,7 +117,7 @@ WarpX::Evolve (int numsteps)
 #ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
 #endif
-         // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
+            // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
             // Need to update Aux on lower levels, to interpolate to higher levels.
 #ifndef WARPX_USE_PSATD
             FillBoundaryAux(guard_cells.ng_UpdateAux);
@@ -356,14 +356,14 @@ WarpX::OneStep_nosub (Real cur_time)
         EvolveF(0.5*dt[0], DtType::FirstHalf);
         FillBoundaryF(guard_cells.ng_FieldSolverF);
 #ifdef WARPX_MAG_LLG
-    EvolveM(0.5*dt[0]); // we now have M^{n+1/2}
+        EvolveM(0.5*dt[0]); // we now have M^{n+1/2}
 #endif
         EvolveB(0.5*dt[0]); // We now have B^{n+1/2}
 
 #ifdef WARPX_MAG_LLG
-    FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+        FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
 #endif
-    FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+        FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         if (WarpX::em_solver_medium == MediumForEM::Vacuum) {
             // vacuum medium
             EvolveE(dt[0]); // We now have E^{n+1}
@@ -377,7 +377,7 @@ WarpX::OneStep_nosub (Real cur_time)
         FillBoundaryE(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         EvolveF(0.5*dt[0], DtType::SecondHalf);
 #ifdef WARPX_MAG_LLG
-    EvolveM(0.5*dt[0]); // we now have M^{n+1}
+        EvolveM(0.5*dt[0]); // we now have M^{n+1}
 #endif
         EvolveB(0.5*dt[0]); // We now have B^{n+1}
         //why not implementing FillBoundary here? possibly: implemented in if{safe_guard_cells} Line 452
@@ -394,7 +394,7 @@ WarpX::OneStep_nosub (Real cur_time)
 #ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
 #endif
-        FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+            FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
         }
 #endif
     }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -95,8 +95,10 @@ WarpX::Evolve (int numsteps)
             // Not called at each iteration, so exchange all guard cells
             FillBoundaryE(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
             FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-            FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-            UpdateAuxilaryData();
+#ifdef WARPX_MAG_LLG
+	    FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+#endif
+	    UpdateAuxilaryData();
             // on first step, push p by -0.5*dt
             for (int lev = 0; lev <= finest_level; ++lev)
             {
@@ -112,8 +114,10 @@ WarpX::Evolve (int numsteps)
             // E and B are up-to-date inside the domain only
             FillBoundaryE(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
             FillBoundaryB(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
+#ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_FieldGather, guard_cells.ng_Extra);
-            // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
+#endif 
+ 	    // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
             // Need to update Aux on lower levels, to interpolate to higher levels.
 #ifndef WARPX_USE_PSATD
             FillBoundaryAux(guard_cells.ng_UpdateAux);
@@ -351,11 +355,15 @@ WarpX::OneStep_nosub (Real cur_time)
 #else
         EvolveF(0.5*dt[0], DtType::FirstHalf);
         FillBoundaryF(guard_cells.ng_FieldSolverF);
-        EvolveM(0.5*dt[0]); // we now have M^{n+1/2}
+#ifdef WARPX_MAG_LLG
+	EvolveM(0.5*dt[0]); // we now have M^{n+1/2}
+#endif
         EvolveB(0.5*dt[0]); // We now have B^{n+1/2}
 
-        FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
-        FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+#ifdef WARPX_MAG_LLG
+	FillBoundaryM(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
+#endif        
+	FillBoundaryB(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         if (WarpX::em_solver_medium == MediumForEM::Vacuum) {
             // vacuum medium
             EvolveE(dt[0]); // We now have E^{n+1}
@@ -368,7 +376,9 @@ WarpX::OneStep_nosub (Real cur_time)
 
         FillBoundaryE(guard_cells.ng_FieldSolver, IntVect::TheZeroVector());
         EvolveF(0.5*dt[0], DtType::SecondHalf);
-        EvolveM(0.5*dt[0]); // we now have M^{n+1}
+#ifdef WARPX_MAG_LLG
+	EvolveM(0.5*dt[0]); // we now have M^{n+1}
+#endif
         EvolveB(0.5*dt[0]); // We now have B^{n+1}
         //why not implementing FillBoundary here? possibly: implemented in if{safe_guard_cells} Line 452
         if (do_pml) {
@@ -381,8 +391,10 @@ WarpX::OneStep_nosub (Real cur_time)
         // E and B are up-to-date in the domain, but all guard cells are
         // outdated.
         if ( safe_guard_cells ){
+#ifdef WARPX_MAG_LLG
             FillBoundaryM(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
-            FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
+#endif            
+	    FillBoundaryB(guard_cells.ng_alloc_EB, guard_cells.ng_Extra);
         }
 #endif
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
@@ -39,9 +39,9 @@ void FiniteDifferenceSolver::EvolveM (
     } */
 
     if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
-        
+
         EvolveMCartesian <CartesianYeeAlgorithm> (Mfield, Bfield, dt);
-        
+
     }
     else {
        amrex::Abort("Only yee algorithm is compatible for M updates.");

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
@@ -13,6 +13,7 @@ blank
 
 using namespace amrex;
 
+#ifdef WARPX_MAG_LLG
 // update M field over one timestep
 
 void FiniteDifferenceSolver::EvolveM (
@@ -44,8 +45,10 @@ void FiniteDifferenceSolver::EvolveM (
     else {
        amrex::Abort("Only yee algorithm is compatible for M updates.");
     }
-    } // closes function EvolveM
+} // closes function EvolveM
+#endif
 
+#ifdef WARPX_MAG_LLG
     template<typename T_Algo>
     void FiniteDifferenceSolver::EvolveMCartesian (
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > & Mfield,
@@ -154,3 +157,5 @@ void FiniteDifferenceSolver::EvolveM (
             );
         }
     }
+
+#endif

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
@@ -38,9 +38,10 @@ void FiniteDifferenceSolver::EvolveM (
         amrex::Abort("Unknown algorithm");
     } */
 
-    if (m_fdtd_algo == MaxwellSolverAlgo::Yee)
-    {
+    if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+        
         EvolveMCartesian <CartesianYeeAlgorithm> (Mfield, Bfield, dt);
+        
     }
     else {
        amrex::Abort("Only yee algorithm is compatible for M updates.");
@@ -153,8 +154,7 @@ void FiniteDifferenceSolver::EvolveM (
               Mz(i, j, k, 2) += dt * cons1 * ( Mz(i, j, k, 0) * By_ztemp - Mz(i, j, k, 1) * Bx_ztemp)
                 + dt * cons2 * ( Mz(i, j, k, 0) * ( Mz(i, j, k, 2) * Bx_ztemp - Mz(i, j, k, 0) * Bz(i, j, k))
                 - Mz(i, j, k, 1) * ( Mz(i, j, k, 1) * Bz(i, j, k) - My(i, j, k, 2) * By_ztemp));
-            }
-            );
+            });
         }
     }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -52,9 +52,13 @@ class FiniteDifferenceSolver
                        int const rhocomp,
                        amrex::Real const dt );
 
+#ifdef WARPX_MAG_LLG
         void EvolveM ( std::array< std::unique_ptr<amrex::MultiFab>, 3 >& Mfield,
                        std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Bfield,
                        amrex::Real const dt);
+
+#endif
+
 
         void ComputeDivE ( const std::array<std::unique_ptr<amrex::MultiFab>,3>& Efield,
                            amrex::MultiFab& divE );
@@ -155,11 +159,13 @@ class FiniteDifferenceSolver
             std::unique_ptr<amrex::MultiFab> const& Ffield,
             amrex::Real const dt );
 
+#ifdef WARPX_MAG_LLG
         template< typename T_Algo >
         void EvolveMCartesian (
             std::array< std::unique_ptr<amrex::MultiFab>, 3 >& Mfield,
             std::array< std::unique_ptr<amrex::MultiFab>, 3 > const& Bfield,
             amrex::Real const dt );
+#endif
 
         template< typename T_Algo >
         void EvolveFCartesian (

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -117,6 +117,7 @@ WarpX::PushPSATD (int lev, amrex::Real /* dt */)
 }
 #endif
 
+#ifdef WARPX_MAG_LLG
 // define WarpX::EvolveM
 void
 WarpX::EvolveM (amrex::Real a_dt)
@@ -223,6 +224,7 @@ WarpX::EvolveM (int lev, PatchType patch_type, amrex::Real a_dt)
         */
     }
 }
+#endif
 
 void
 WarpX::EvolveB (amrex::Real a_dt)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -298,6 +298,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
            }
         }
 
+#ifdef WARPX_MAG_LLG
         if (M_ext_grid_s == "constant" || M_ext_grid_s == "default"){
             // this if condition finds out if the user-input is constant
             // if not, set initial value to default, default = 0.0
@@ -315,9 +316,10 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             for (int icomp = 0; icomp < 3; ++icomp){ // icomp is the index of components at each i face
                 Mfield_fp[lev][i]->setVal(M_external_grid[icomp], icomp, 1, nghost);
             }
-
         }
-    }
+#endif
+
+   }
 
     // if the input string for the B-field is "parse_b_ext_grid_function",
     // then the analytical expression or function must be

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -57,6 +57,10 @@ else
 endif
 endif
 
+ifeq ($(USE_LLG),TRUE)
+  DEFINES += -DWARPX_MAG_LLG
+endif
+
 -include Make.package
 include $(WARPX_HOME)/Source/Make.package
 include $(WARPX_HOME)/Source/BoundaryConditions/Make.package

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -474,6 +474,7 @@ WarpX::FillBoundaryB (int lev, PatchType patch_type, IntVect ng)
     }
 }
 
+#ifdef WARPX_MAG_LLG
 void
 WarpX::FillBoundaryM (IntVect ng, IntVect ng_extra_fine)
 {
@@ -548,6 +549,7 @@ WarpX::FillBoundaryM (int lev, PatchType patch_type, IntVect ng)
         */
     }
 }
+#endif
 
 void
 WarpX::FillBoundaryF (int lev, IntVect ng)

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -212,7 +212,7 @@ public:
         };
     }
 
-#ifdef WARPX_MAG_LLG    
+#ifdef WARPX_MAG_LLG
     std::array<const amrex::MultiFab* const, 3>
     get_array_Mfield_aux  (const int lev) const {
         return {
@@ -221,7 +221,7 @@ public:
             Mfield_aux[lev][2].get()
         };
     }
-#endif 
+#endif
 
     amrex::MultiFab * get_pointer_Efield_aux  (int lev, int direction) const { return Efield_aux[lev][direction].get(); }
     amrex::MultiFab * get_pointer_Bfield_aux  (int lev, int direction) const { return Bfield_aux[lev][direction].get(); }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -211,6 +211,8 @@ public:
             Efield_aux[lev][2].get()
         };
     }
+
+#ifdef WARPX_MAG_LLG    
     std::array<const amrex::MultiFab* const, 3>
     get_array_Mfield_aux  (const int lev) const {
         return {
@@ -219,22 +221,31 @@ public:
             Mfield_aux[lev][2].get()
         };
     }
+#endif 
 
     amrex::MultiFab * get_pointer_Efield_aux  (int lev, int direction) const { return Efield_aux[lev][direction].get(); }
     amrex::MultiFab * get_pointer_Bfield_aux  (int lev, int direction) const { return Bfield_aux[lev][direction].get(); }
+#ifdef WARPX_MAG_LLG
     amrex::MultiFab * get_pointer_Mfield_aux  (int lev, int direction) const { return Mfield_aux[lev][direction].get(); }
+#endif
 
     amrex::MultiFab * get_pointer_Efield_fp  (int lev, int direction) const { return Efield_fp[lev][direction].get(); }
     amrex::MultiFab * get_pointer_Bfield_fp  (int lev, int direction) const { return Bfield_fp[lev][direction].get(); }
+
+#ifdef WARPX_MAG_LLG
     // note "direction" of M means face.  For M, each face stores all 3 vector components of M
     amrex::MultiFab * get_pointer_Mfield_fp  (int lev, int direction) const { return Mfield_fp[lev][direction].get();}
+#endif
+
     amrex::MultiFab * get_pointer_current_fp  (int lev, int direction) const { return current_fp[lev][direction].get(); }
     amrex::MultiFab * get_pointer_rho_fp  (int lev) const { return rho_fp[lev].get(); }
     amrex::MultiFab * get_pointer_F_fp  (int lev) const { return F_fp[lev].get(); }
 
     amrex::MultiFab * get_pointer_Efield_cp  (int lev, int direction) const { return Efield_cp[lev][direction].get(); }
     amrex::MultiFab * get_pointer_Bfield_cp  (int lev, int direction) const { return Bfield_cp[lev][direction].get(); }
+#ifdef WARPX_MAG_LLG
     amrex::MultiFab * get_pointer_Mfield_cp  (int lev, int direction) const { return Mfield_cp[lev][direction].get(); }
+#endif
     amrex::MultiFab * get_pointer_current_cp  (int lev, int direction) const { return current_cp[lev][direction].get(); }
     amrex::MultiFab * get_pointer_rho_cp  (int lev) const { return rho_cp[lev].get(); }
     amrex::MultiFab * get_pointer_F_cp  (int lev) const { return F_cp[lev].get(); }
@@ -242,18 +253,24 @@ public:
     const amrex::MultiFab& getcurrent (int lev, int direction) {return *current_fp[lev][direction];}
     const amrex::MultiFab& getEfield  (int lev, int direction) {return *Efield_aux[lev][direction];}
     const amrex::MultiFab& getBfield  (int lev, int direction) {return *Bfield_aux[lev][direction];}
+#ifdef WARPX_MAG_LLG
     const amrex::MultiFab& getMfield  (int lev, int direction) {return *Mfield_aux[lev][direction];}
+#endif
 
     const amrex::MultiFab& getcurrent_cp (int lev, int direction) {return *current_cp[lev][direction];}
     const amrex::MultiFab& getEfield_cp  (int lev, int direction) {return  *Efield_cp[lev][direction];}
     const amrex::MultiFab& getBfield_cp  (int lev, int direction) {return  *Bfield_cp[lev][direction];}
+#ifdef WARPX_MAG_LLG
     const amrex::MultiFab& getMfield_cp  (int lev, int direction) {return  *Mfield_cp[lev][direction];}
+#endif
     const amrex::MultiFab& getrho_cp (int lev) {return  *rho_cp[lev];}
 
     const amrex::MultiFab& getcurrent_fp (int lev, int direction) {return *current_fp[lev][direction];}
     const amrex::MultiFab& getEfield_fp  (int lev, int direction) {return *Efield_fp[lev][direction];}
     const amrex::MultiFab& getBfield_fp  (int lev, int direction) {return *Bfield_fp[lev][direction];}
+#ifdef WARPX_MAG_LLG
     const amrex::MultiFab& getMfield_fp  (int lev, int direction) {return *Mfield_fp[lev][direction];}
+#endif
     const amrex::MultiFab& getrho_fp (int lev) {return *rho_fp[lev];}
     const amrex::MultiFab& getF_fp (int lev) {return *F_fp[lev];}
     bool DoPML () const {return do_pml;};
@@ -652,7 +669,9 @@ private:
     // Full solution
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_aux;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_aux;
+#ifdef WARPX_MAG_LLG
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Mfield_aux;
+#endif
 
     // Fine patch
     amrex::Vector<            std::unique_ptr<amrex::MultiFab>      > F_fp;
@@ -660,7 +679,9 @@ private:
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > current_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_fp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_fp;
+#ifdef WARPX_MAG_LLG
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Mfield_fp;
+#endif
     // define Mfield MultiFab; only fine patches
 
     // store fine patch
@@ -672,7 +693,9 @@ private:
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > current_cp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_cp;
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Bfield_cp;
+#ifdef WARPX_MAG_LLG
     amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Mfield_cp;
+#endif
 
     // Copy of the coarse aux
     amrex::Vector<std::array<std::unique_ptr<amrex::MultiFab>, 3 > > Efield_cax;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -708,9 +708,8 @@ WarpX::ClearLevel (int lev)
     for (int i = 0; i < 3; ++i) {
         Efield_aux[lev][i].reset();
         Bfield_aux[lev][i].reset();
-
 #ifdef WARPX_MAG_LLG
-    Mfield_aux[lev][i].reset();
+        Mfield_aux[lev][i].reset();
 #endif
 
         current_fp[lev][i].reset();
@@ -970,7 +969,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             Efield_aux[lev][idir].reset(new MultiFab(*Efield_fp[lev][idir], amrex::make_alias, 0, ncomps));
             Bfield_aux[lev][idir].reset(new MultiFab(*Bfield_fp[lev][idir], amrex::make_alias, 0, ncomps));
 #ifdef WARPX_MAG_LLG
-        Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
+            Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
 #endif
     }
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -194,14 +194,18 @@ WarpX::WarpX ()
 
     Efield_aux.resize(nlevs_max);
     Bfield_aux.resize(nlevs_max);
+#ifdef WARPX_MAG_LLG
     Mfield_aux.resize(nlevs_max);
+#endif
 
     F_fp.resize(nlevs_max);
     rho_fp.resize(nlevs_max);
     current_fp.resize(nlevs_max);
     Efield_fp.resize(nlevs_max);
     Bfield_fp.resize(nlevs_max);
+#ifdef WARPX_MAG_LLG
     Mfield_fp.resize(nlevs_max);
+#endif
 
     current_store.resize(nlevs_max);
 
@@ -210,7 +214,9 @@ WarpX::WarpX ()
     current_cp.resize(nlevs_max);
     Efield_cp.resize(nlevs_max);
     Bfield_cp.resize(nlevs_max);
+#ifdef WARPX_MAG_LLG
     Mfield_cp.resize(nlevs_max);
+#endif
 
     Efield_cax.resize(nlevs_max);
     Bfield_cax.resize(nlevs_max);
@@ -702,19 +708,26 @@ WarpX::ClearLevel (int lev)
     for (int i = 0; i < 3; ++i) {
         Efield_aux[lev][i].reset();
         Bfield_aux[lev][i].reset();
-        Mfield_aux[lev][i].reset();
+
+#ifdef WARPX_MAG_LLG 
+	Mfield_aux[lev][i].reset();
+#endif
 
         current_fp[lev][i].reset();
         Efield_fp [lev][i].reset();
         Bfield_fp [lev][i].reset();
+#ifdef WARPX_MAG_LLG 
         Mfield_fp [lev][i].reset();
+#endif
 
         current_store[lev][i].reset();
 
         current_cp[lev][i].reset();
         Efield_cp [lev][i].reset();
         Bfield_cp [lev][i].reset();
+#ifdef WARPX_MAG_LLG 
         Mfield_cp [lev][i].reset();
+#endif
 
         Efield_cax[lev][i].reset();
         Bfield_cax[lev][i].reset();
@@ -874,9 +887,11 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     Efield_fp[lev][1].reset( new MultiFab(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE+ngextra));
     Efield_fp[lev][2].reset( new MultiFab(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE+ngextra));
 
+#ifdef WARPX_MAG_LLG    
     Mfield_fp[lev][0].reset( new MultiFab(amrex::convert(ba,Mx_nodal_flag),dm,3,ngE+ngextra));
     Mfield_fp[lev][1].reset( new MultiFab(amrex::convert(ba,My_nodal_flag),dm,3,ngE+ngextra));
     Mfield_fp[lev][2].reset( new MultiFab(amrex::convert(ba,Mz_nodal_flag),dm,3,ngE+ngextra)); // each Mfield[] is three components
+#endif 
 
     current_fp[lev][0].reset( new MultiFab(amrex::convert(ba,jx_nodal_flag),dm,ncomps,ngJ));
     current_fp[lev][1].reset( new MultiFab(amrex::convert(ba,jy_nodal_flag),dm,ncomps,ngJ));
@@ -954,8 +969,10 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         for (int idir = 0; idir < 3; ++idir) {
             Efield_aux[lev][idir].reset(new MultiFab(*Efield_fp[lev][idir], amrex::make_alias, 0, ncomps));
             Bfield_aux[lev][idir].reset(new MultiFab(*Bfield_fp[lev][idir], amrex::make_alias, 0, ncomps));
-            Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
-        }
+#ifdef WARPX_MAG_LLG    
+	    Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
+#endif 
+	}
     }
     else
     {
@@ -967,9 +984,11 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         Efield_aux[lev][1].reset( new MultiFab(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE));
         Efield_aux[lev][2].reset( new MultiFab(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE));
 
+#ifdef WARPX_MAG_LLG    
         Mfield_aux[lev][0].reset( new MultiFab(amrex::convert(ba,Mx_nodal_flag),dm,3     ,ngE));
         Mfield_aux[lev][1].reset( new MultiFab(amrex::convert(ba,My_nodal_flag),dm,3     ,ngE));
         Mfield_aux[lev][2].reset( new MultiFab(amrex::convert(ba,Mz_nodal_flag),dm,3     ,ngE));
+#endif
     }
 
     //
@@ -991,10 +1010,12 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         Efield_cp[lev][1].reset( new MultiFab(amrex::convert(cba,Ey_nodal_flag),dm,ncomps,ngE));
         Efield_cp[lev][2].reset( new MultiFab(amrex::convert(cba,Ez_nodal_flag),dm,ncomps,ngE));
 
-        // Create the MultiFabs for M
+#ifdef WARPX_MAG_LLG
+	// Create the MultiFabs for M
         Mfield_cp[lev][0].reset( new MultiFab(amrex::convert(cba,Mx_nodal_flag),dm,3     ,ngE));
         Mfield_cp[lev][1].reset( new MultiFab(amrex::convert(cba,My_nodal_flag),dm,3     ,ngE));
         Mfield_cp[lev][2].reset( new MultiFab(amrex::convert(cba,Mz_nodal_flag),dm,3     ,ngE));
+#endif 
 
         // Create the MultiFabs for the current
         current_cp[lev][0].reset( new MultiFab(amrex::convert(cba,jx_nodal_flag),dm,ncomps,ngJ));

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -971,7 +971,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 #ifdef WARPX_MAG_LLG
             Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
 #endif
-    }
+        }
     }
     else
     {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -709,14 +709,14 @@ WarpX::ClearLevel (int lev)
         Efield_aux[lev][i].reset();
         Bfield_aux[lev][i].reset();
 
-#ifdef WARPX_MAG_LLG 
+#ifdef WARPX_MAG_LLG
     Mfield_aux[lev][i].reset();
 #endif
 
         current_fp[lev][i].reset();
         Efield_fp [lev][i].reset();
         Bfield_fp [lev][i].reset();
-#ifdef WARPX_MAG_LLG 
+#ifdef WARPX_MAG_LLG
         Mfield_fp [lev][i].reset();
 #endif
 
@@ -725,7 +725,7 @@ WarpX::ClearLevel (int lev)
         current_cp[lev][i].reset();
         Efield_cp [lev][i].reset();
         Bfield_cp [lev][i].reset();
-#ifdef WARPX_MAG_LLG 
+#ifdef WARPX_MAG_LLG
         Mfield_cp [lev][i].reset();
 #endif
 
@@ -887,11 +887,11 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     Efield_fp[lev][1].reset( new MultiFab(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE+ngextra));
     Efield_fp[lev][2].reset( new MultiFab(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE+ngextra));
 
-#ifdef WARPX_MAG_LLG    
+#ifdef WARPX_MAG_LLG
     Mfield_fp[lev][0].reset( new MultiFab(amrex::convert(ba,Mx_nodal_flag),dm,3,ngE+ngextra));
     Mfield_fp[lev][1].reset( new MultiFab(amrex::convert(ba,My_nodal_flag),dm,3,ngE+ngextra));
     Mfield_fp[lev][2].reset( new MultiFab(amrex::convert(ba,Mz_nodal_flag),dm,3,ngE+ngextra)); // each Mfield[] is three components
-#endif 
+#endif
 
     current_fp[lev][0].reset( new MultiFab(amrex::convert(ba,jx_nodal_flag),dm,ncomps,ngJ));
     current_fp[lev][1].reset( new MultiFab(amrex::convert(ba,jy_nodal_flag),dm,ncomps,ngJ));
@@ -969,9 +969,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         for (int idir = 0; idir < 3; ++idir) {
             Efield_aux[lev][idir].reset(new MultiFab(*Efield_fp[lev][idir], amrex::make_alias, 0, ncomps));
             Bfield_aux[lev][idir].reset(new MultiFab(*Bfield_fp[lev][idir], amrex::make_alias, 0, ncomps));
-#ifdef WARPX_MAG_LLG    
+#ifdef WARPX_MAG_LLG
         Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
-#endif 
+#endif
     }
     }
     else
@@ -984,7 +984,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         Efield_aux[lev][1].reset( new MultiFab(amrex::convert(ba,Ey_nodal_flag),dm,ncomps,ngE));
         Efield_aux[lev][2].reset( new MultiFab(amrex::convert(ba,Ez_nodal_flag),dm,ncomps,ngE));
 
-#ifdef WARPX_MAG_LLG    
+#ifdef WARPX_MAG_LLG
         Mfield_aux[lev][0].reset( new MultiFab(amrex::convert(ba,Mx_nodal_flag),dm,3     ,ngE));
         Mfield_aux[lev][1].reset( new MultiFab(amrex::convert(ba,My_nodal_flag),dm,3     ,ngE));
         Mfield_aux[lev][2].reset( new MultiFab(amrex::convert(ba,Mz_nodal_flag),dm,3     ,ngE));
@@ -1015,7 +1015,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         Mfield_cp[lev][0].reset( new MultiFab(amrex::convert(cba,Mx_nodal_flag),dm,3     ,ngE));
         Mfield_cp[lev][1].reset( new MultiFab(amrex::convert(cba,My_nodal_flag),dm,3     ,ngE));
         Mfield_cp[lev][2].reset( new MultiFab(amrex::convert(cba,Mz_nodal_flag),dm,3     ,ngE));
-#endif 
+#endif
 
         // Create the MultiFabs for the current
         current_cp[lev][0].reset( new MultiFab(amrex::convert(cba,jx_nodal_flag),dm,ncomps,ngJ));

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -710,7 +710,7 @@ WarpX::ClearLevel (int lev)
         Bfield_aux[lev][i].reset();
 
 #ifdef WARPX_MAG_LLG 
-	Mfield_aux[lev][i].reset();
+    Mfield_aux[lev][i].reset();
 #endif
 
         current_fp[lev][i].reset();
@@ -970,9 +970,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             Efield_aux[lev][idir].reset(new MultiFab(*Efield_fp[lev][idir], amrex::make_alias, 0, ncomps));
             Bfield_aux[lev][idir].reset(new MultiFab(*Bfield_fp[lev][idir], amrex::make_alias, 0, ncomps));
 #ifdef WARPX_MAG_LLG    
-	    Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
+        Mfield_aux[lev][idir].reset(new MultiFab(*Mfield_fp[lev][idir], amrex::make_alias, 0, 3     ));
 #endif 
-	}
+    }
     }
     else
     {
@@ -1011,7 +1011,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         Efield_cp[lev][2].reset( new MultiFab(amrex::convert(cba,Ez_nodal_flag),dm,ncomps,ngE));
 
 #ifdef WARPX_MAG_LLG
-	// Create the MultiFabs for M
+    // Create the MultiFabs for M
         Mfield_cp[lev][0].reset( new MultiFab(amrex::convert(cba,Mx_nodal_flag),dm,3     ,ngE));
         Mfield_cp[lev][1].reset( new MultiFab(amrex::convert(cba,My_nodal_flag),dm,3     ,ngE));
         Mfield_cp[lev][2].reset( new MultiFab(amrex::convert(cba,Mz_nodal_flag),dm,3     ,ngE));


### PR DESCRIPTION
I added the USE_LLG macro and modified the following files so that we can choose whether the LLG equation is used or not. If USE_LLG = false, there are not M fields. 

GNUmakefile
Source/Diagnostics/Diagnostics.cpp
Source/Diagnostics/WarpXIO.cpp
Source/Evolve/WarpXEvolve.cpp
Source/FieldSolver/FiniteDifferenceSolver/EvolveM.cpp
Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
Source/FieldSolver/WarpXPushFieldsEM.cpp
Source/Initialization/WarpXInitData.cpp
Source/Parallelization/WarpXComm.cpp
Source/WarpX.H
Source/WarpX.cpp

I also compare the outputs between USE_LLG = false and USE_LLG = true and make sure these modifications do not influence the B and E fields.  The inputs file 
[inputs_wllg.txt](https://github.com/RevathiJambunathan/WarpX/files/4750125/inputs_wllg.txt)
is used while USE_LLG = true and the inputs file 
[inputs_wollg.txt](https://github.com/RevathiJambunathan/WarpX/files/4750126/inputs_wollg.txt)
is used while USE_LLG = false.



