### PR TITLE
Fix typo and bug in MacroscopicEvolveECartesian

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -189,14 +189,6 @@ class FiniteDifferenceSolver
             std::unique_ptr<MacroscopicProperties> const& macroscopic_properties);
 
         template< typename T_Algo >
-        void MacroscopicEvolveECartesian (
-            std::array< std::unique_ptr< amrex::MultiFab>, 3>& Efield,
-            std::array< std::unique_ptr< amrex::MultiFab>, 3> const &Bfield,
-            std::array< std::unique_ptr< amrex::MultiFab>, 3> const& Jfield,
-            amrex::Real const dt,
-            std::unique_ptr<MacroscopicProperties> const& macroscopic_properties);
-
-        template< typename T_Algo >
         void EvolveBPMLCartesian (
             std::array< amrex::MultiFab*, 3 > Bfield,
             std::array< amrex::MultiFab*, 3 > const Efield,

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -50,7 +50,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveE (
             MacroscopicEvolveECartesian <CartesianCKCAlgorithm, LaxWendroffAlgo>
                        ( Efield, Bfield, Jfield, dt, macroscopic_properties );
 
-        } else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::LaxWendroff) {
+        } else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::BackwardEuler) {
 
             MacroscopicEvolveECartesian <CartesianCKCAlgorithm, BackwardEulerAlgo>
                        ( Efield, Bfield, Jfield, dt, macroscopic_properties );


### PR DESCRIPTION
In this PR, I am fixing a bug that Jackie had noted during the PR discussion about evolvMCartesian.
The call to BackwardEuler is now consistent with BackwardEulerMethod.
Also, the initialization of MacroscopicEvolveECartesian takes in two templated variables.
I have removed the old one that was still lingering in `Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H`

