### PR TITLE
Init guard cells as well for macroproperties

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -100,11 +100,11 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     auto& warpx = WarpX::GetInstance();
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
+    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(3);
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        IntVect iv = macro_mf->ixType().toIntVect();
-        // Initialize ghost cells in addition to valid cells
-        const Box& tb = convert(mfi.growntilebox(), iv);
+        // Initialize ghost cells in addition to valid cells vy using iv
+        const Box& tb = mfi.growntilebox(iv);
 
         auto const& macro_fab =  macro_mf->array(mfi);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -100,11 +100,13 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     auto& warpx = WarpX::GetInstance();
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
-    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(macro_mf->nGrow());
+    IntVect iv = macro_mf->ixType().toIntVect();     
+    // IntVect to include staggering of MultiFab and account for guard cells
+    IntVect iv_grownBox = iv + amrex::IntVect( macro_mf->nGrow() );
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        // Initialize ghost cells in addition to valid cells vy using iv
-        const Box& tb = mfi.growntilebox(iv);
+        // Initialize ghost cells in addition to valid cells vy using iv_grownBox
+        const Box& tb = mfi.growntilebox(iv_grownBox);
 
         auto const& macro_fab =  macro_mf->array(mfi);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -100,7 +100,7 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     auto& warpx = WarpX::GetInstance();
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
-    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(3);
+    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(macro_mf->nGrow());
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
         // Initialize ghost cells in addition to valid cells vy using iv


### PR DESCRIPTION
In this PR, I am correcting the initialization for MacroProperties by also includng the guard cells when generating the growntilebox(iv), where,  amrex::IntVect iv = macro_mf.ixType().toIntVect() + amrex::IntVect(3). 