### PR TITLE
Evolve m dev fix guard cells for macro part2

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -100,11 +100,11 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     auto& warpx = WarpX::GetInstance();
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
+    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(3);
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        IntVect iv = macro_mf->ixType().toIntVect();
-        // Initialize ghost cells in addition to valid cells
-        const Box& tb = convert(mfi.growntilebox(), iv);
+        // Initialize ghost cells in addition to valid cells vy using iv
+        const Box& tb = mfi.growntilebox(iv);
 
         auto const& macro_fab =  macro_mf->array(mfi);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -100,11 +100,13 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     auto& warpx = WarpX::GetInstance();
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
-    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(macro_mf->nGrow());
+    IntVect iv = macro_mf->ixType().toIntVect();     
+    // IntVect to include staggering of MultiFab and account for guard cells
+    IntVect iv_grownBox = iv + amrex::IntVect( macro_mf->nGrow() );
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        // Initialize ghost cells in addition to valid cells vy using iv
-        const Box& tb = mfi.growntilebox(iv);
+        // Initialize ghost cells in addition to valid cells vy using iv_grownBox
+        const Box& tb = mfi.growntilebox(iv_grownBox);
 
         auto const& macro_fab =  macro_mf->array(mfi);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -104,7 +104,7 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
         // Initialize ghost cells in addition to valid cells by calling nGrow()
-        const Box& tb = mfi.growntilebox(iv, macro_mf->nGrow() );
+        const Box& tb = mfi.tilebox(iv, macro_mf->nGrowVect() );
 
         auto const& macro_fab =  macro_mf->array(mfi);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -100,7 +100,7 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     auto& warpx = WarpX::GetInstance();
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
-    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(3);
+    IntVect iv = macro_mf->ixType().toIntVect() + amrex::IntVect(macro_mf->nGrow());
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
         // Initialize ghost cells in addition to valid cells vy using iv

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -101,12 +101,10 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     const auto dx_lev = warpx.Geom(lev).CellSizeArray();
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
     IntVect iv = macro_mf->ixType().toIntVect();     
-    // IntVect to include staggering of MultiFab and account for guard cells
-    IntVect iv_grownBox = iv + amrex::IntVect( macro_mf->nGrow() );
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
         // Initialize ghost cells in addition to valid cells vy using iv_grownBox
-        const Box& tb = mfi.growntilebox(iv_grownBox);
+        const Box& tb = mfi.growntilebox( macro_mf->nGrow() );
 
         auto const& macro_fab =  macro_mf->array(mfi);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -103,8 +103,8 @@ MacroscopicProperties::InitializeMacroMultiFabUsingParser (
     IntVect iv = macro_mf->ixType().toIntVect();     
     for ( MFIter mfi(*macro_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        // Initialize ghost cells in addition to valid cells vy using iv_grownBox
-        const Box& tb = mfi.growntilebox( macro_mf->nGrow() );
+        // Initialize ghost cells in addition to valid cells by calling nGrow()
+        const Box& tb = mfi.growntilebox(iv, macro_mf->nGrow() );
 
         auto const& macro_fab =  macro_mf->array(mfi);
 


### PR DESCRIPTION
Fixing the initialization for macroscopic properties to include guard cells