### PR TITLE
Mag normalization 2nd and H coupling

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1069,6 +1069,9 @@ Numerics and algorithms
 
 * ``warpx.mag_time_scheme_order`` (`1` or `2`; default: `1`)
     The value of the time advancement scheme of M field. `mag_time_scheme_order==1` is the 1st-order Eulerian scheme and `mag_time_scheme_order==2` is the 2nd-order trapezoidal scheme for the LLG equation. This requires `USE_LLG=TRUE` in the GNUMakefile.
+    
+* ``warpx.mag_secondorder_normalization`` (`1` or `2`; default: `1`)
+    When to apply normalization in the second-order magnetization scheme. `mag_secondorder_normalization==1` applies it after each iteration; `mag_secondorder_normalization==2` applies it after the iterations have converged. This requires `USE_LLG=TRUE` in the GNUMakefile.
 
 * ``interpolation.nox``, ``interpolation.noy``, ``interpolation.noz`` (`1`, `2`, or `3` ; default: 1)
     The order of the shape factors for the macroparticles, for the 3 dimensions of space.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1069,10 +1069,10 @@ Numerics and algorithms
 
 * ``warpx.mag_time_scheme_order`` (`1` or `2`; default: `1`)
     The value of the time advancement scheme of M field. `mag_time_scheme_order==1` is the 1st-order Eulerian scheme and `mag_time_scheme_order==2` is the 2nd-order trapezoidal scheme for the LLG equation. This requires `USE_LLG=TRUE` in the GNUMakefile.
-    
+
 * ``warpx.mag_secondorder_normalization`` (`1` or `2`; default: `1`)
     When to apply normalization in the second-order magnetization scheme. `mag_secondorder_normalization==1` applies it after each iteration; `mag_secondorder_normalization==2` applies it after the iterations have converged. This requires `USE_LLG=TRUE` in the GNUMakefile.
-    
+
 * ``warpx.mag_LLG_coupling`` (`0` or `1`; default: `1`)
     Turn on coupling of Maxwell solution to the LLG updates. `mag_LLG_coupling==1` enables, `mag_LLG_coupling=0` diables. This requires `USE_LLG=TRUE` in the GNUMakefile.
 

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -1072,6 +1072,9 @@ Numerics and algorithms
     
 * ``warpx.mag_secondorder_normalization`` (`1` or `2`; default: `1`)
     When to apply normalization in the second-order magnetization scheme. `mag_secondorder_normalization==1` applies it after each iteration; `mag_secondorder_normalization==2` applies it after the iterations have converged. This requires `USE_LLG=TRUE` in the GNUMakefile.
+    
+* ``warpx.mag_LLG_coupling`` (`0` or `1`; default: `1`)
+    Turn on coupling of Maxwell solution to the LLG updates. `mag_LLG_coupling==1` enables, `mag_LLG_coupling=0` diables. This requires `USE_LLG=TRUE` in the GNUMakefile.
 
 * ``interpolation.nox``, ``interpolation.noy``, ``interpolation.noz`` (`1`, `2`, or `3` ; default: 1)
     The order of the shape factors for the macroparticles, for the 3 dimensions of space.

--- a/Examples/Tests/Macroscopic_Maxwell/inputs_3d.evolveM2nd
+++ b/Examples/Tests/Macroscopic_Maxwell/inputs_3d.evolveM2nd
@@ -21,6 +21,8 @@ warpx.use_filter = 0
 warpx.cfl = 4000
 warpx.do_pml = 0
 warpx.mag_time_scheme_order = 2 # default 1
+warpx.mag_secondorder_normalization = 1
+warpx.mag_LLG_coupling = 1
 particles.nspecies = 0
 
 algo.em_solver_medium = macroscopic # vacuum/macroscopic

--- a/Examples/Tests/Macroscopic_Maxwell/inputs_3d.evolveM2nd
+++ b/Examples/Tests/Macroscopic_Maxwell/inputs_3d.evolveM2nd
@@ -18,7 +18,7 @@ amr.max_level = 0
 #################################
 warpx.verbose = 0
 warpx.use_filter = 0
-warpx.cfl = 4000
+warpx.cfl = 0.9
 warpx.do_pml = 0
 warpx.mag_time_scheme_order = 2 # default 1
 warpx.mag_secondorder_normalization = 1

--- a/Examples/Tests/Macroscopic_Maxwell/inputs_3d.evolveM2nd
+++ b/Examples/Tests/Macroscopic_Maxwell/inputs_3d.evolveM2nd
@@ -69,13 +69,13 @@ warpx.E_ext_grid_init_style = parse_E_ext_grid_function
 
 warpx.Ex_external_grid_function(x,y,z) = 0.
 warpx.Ey_external_grid_function(x,y,z) = 0.
-#warpx.Ey_external_grid_function(x,y,z) = "1.e5exp(-z2/L2)cos(2piz/wavelength)"
+#warpx.Ey_external_grid_function(x,y,z) = "1.e5*exp(-z**2/L**2)*cos(2*pi*z/wavelength)"
 warpx.Ez_external_grid_function(x,y,z) = 0.
 
 warpx.B_ext_grid_init_style = parse_B_ext_grid_function
 warpx.Bx_external_grid_function(x,y,z)= 0.1759
 #warpx.Bx_external_grid_function(x,y,z)= 0.
-#warpx.Bx_external_grid_function(x,y,z)= "-1.e5exp(-z2/L2)cos(2piz/wavelength)/c"
+#warpx.Bx_external_grid_function(x,y,z)= "-1.e5*exp(-z**2/L**2)*cos(2*pi*z/wavelength)/c"
 warpx.By_external_grid_function(x,y,z)= 0.
 warpx.Bz_external_grid_function(x,y,z) = 0.
 
@@ -94,7 +94,7 @@ warpx.Hz_bias_external_grid_function(x,y,z)= 3e4 # in A/m, equal to 382 Oersted
 #warpx.Hz_bias_external_grid = 0
 
 #warpx.M_ext_grid_init_style = parse_M_ext_grid_function
-#warpx.Mx_external_grid_function(x,y,z)= "-1.e5exp(-z2/L2)cos(2piz/wavelength)/c"
+#warpx.Mx_external_grid_function(x,y,z)= "-1.e5*exp(-z**2/L**2)*cos(2*pi*z/wavelength)/c"
 #warpx.My_external_grid_function(x,y,z)= 0.
 #warpx.Mz_external_grid_function(x,y,z) = 0.
 

--- a/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.cpp
@@ -34,6 +34,6 @@ CellCenterFunctor::operator()(amrex::MultiFab& mf_dst, int dcomp, const int /*i_
 #else
     // In cartesian geometry, coarsen and interpolate from simulation MultiFab, m_mf_src,
     // to output diagnostic MultiFab, mf_dst.
-    CoarsenIO::Coarsen( mf_dst, *m_mf_src, dcomp, 0, nComp(), mf_dst.nGrow(0), m_crse_ratio);
+    CoarsenIO::Coarsen( mf_dst, *m_mf_src, dcomp, m_scomp, nComp(), mf_dst.nGrow(0), m_crse_ratio);
 #endif
 }

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM.cpp
@@ -47,7 +47,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM (
 
         auto& warpx = WarpX::GetInstance();
         int coupling = warpx.mag_LLG_coupling;
-        
+
         // build temporary vector<multifab,3> Mfield_prev
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > Mfield_prev; // Mfield data in previous step
         for (int i = 0; i < 3; i++){

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM.cpp
@@ -2,6 +2,7 @@
 blank
 */
 
+#include "WarpX.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "FiniteDifferenceSolver.H"
 #include "FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
@@ -44,6 +45,9 @@ void FiniteDifferenceSolver::MacroscopicEvolveM (
         std::unique_ptr<MacroscopicProperties> const& macroscopic_properties )
     {
 
+        auto& warpx = WarpX::GetInstance();
+        int coupling = warpx.mag_LLG_coupling;
+        
         // build temporary vector<multifab,3> Mfield_prev
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > Mfield_prev; // Mfield data in previous step
         for (int i = 0; i < 3; i++){
@@ -97,19 +101,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM (
 
               // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
               // Hy and Hz can be acquired by interpolation
-              // H_maxwell
-              Real Hx_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Bx, M_xface);
-              Real Hy_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), By, M_xface);
-              Real Hz_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Bz, M_xface);
 
               // H_bias
-              Real Hx_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Hx_bias);
-              Real Hy_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), Hy_bias);
-              Real Hz_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_xface + Hx_bias_xface;
-              Real Hy_eff = Hy_xface + Hy_bias_xface;
-              Real Hz_eff = Hz_xface + Hz_bias_xface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Hz_bias);
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Bx, M_xface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), By, M_xface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Bz, M_xface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation. The IntVect is (1,0,0) to interpolate values to the x-face.
@@ -156,18 +160,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM (
 
               // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
               // Hy and Hz can be acquired by interpolation
-              // H_maxwell
-              Real Hx_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Bx, M_yface);
-              Real Hy_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), By, M_yface);
-              Real Hz_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Bz, M_yface);
+
               // H_bias
-              Real Hx_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Hx_bias);
-              Real Hy_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), Hy_bias);
-              Real Hz_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_yface + Hx_bias_yface;
-              Real Hy_eff = Hy_yface + Hy_bias_yface;
-              Real Hz_eff = Hz_yface + Hz_bias_yface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Hz_bias);
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Bx, M_yface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), By, M_yface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Bz, M_yface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation. The IntVect is (0,1,0) to interpolate values to the y-face.
@@ -213,19 +218,20 @@ void FiniteDifferenceSolver::MacroscopicEvolveM (
 
               // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
               // Hy and Hz can be acquired by interpolation
-              // H_maxwell
-              Real Hx_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Bx, M_zface);
-              Real Hy_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), By, M_zface);
-              Real Hz_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Bz, M_zface);
 
               // H_bias
-              Real Hx_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Hx_bias);
-              Real Hy_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), Hy_bias);
-              Real Hz_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_zface + Hx_bias_zface;
-              Real Hy_eff = Hy_zface + Hy_bias_zface;
-              Real Hz_eff = Hz_zface + Hz_bias_zface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Bx, M_zface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), By, M_zface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Bz, M_zface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation. The IntVect is (0,0,1) to interpolate values to the z-face.

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
@@ -53,7 +53,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
         auto& warpx = WarpX::GetInstance();
         int coupling = warpx.mag_LLG_coupling;
         int normalization_type = warpx.mag_secondorder_normalization;
-        
+
         // build temporary vector<multifab,3> Mfield_prev, Mfield_error, a_temp, a_temp_static, b_temp_static
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > Mfield_prev; // M^n before the iteration
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > Mfield_error; // The error of the M field between the twoiterations
@@ -391,7 +391,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               M_xface(i, j, k, 2) = MacroscopicProperties::updateM_field(i, j, k, 2, a_temp_xface, b_temp_static_xface);
 
               if (normalization_type == 1) {
-              
+
                   // temporary normalized magnitude of M_xface field at the fixed point
                   // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                   amrex::Real mag_normalized = std::sqrt( std::pow(M_xface(i, j, k, 0),2.0) + std::pow(M_xface(i, j, k, 1),2.0) +
@@ -470,7 +470,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               M_yface(i, j, k, 2) = MacroscopicProperties::updateM_field(i, j, k, 2, a_temp_yface, b_temp_static_yface);
 
               if (normalization_type == 1) {
-                  
+
                   // temporary normalized magnitude of M_yface field at the fixed point
                   // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                   amrex::Real mag_normalized = std::sqrt( std::pow(M_yface(i, j, k, 0),2.0) + std::pow(M_yface(i, j, k, 1),2.0) +
@@ -548,7 +548,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               M_zface(i, j, k, 2) = MacroscopicProperties::updateM_field(i, j, k, 2, a_temp_zface, b_temp_static_zface);
 
               if (normalization_type == 1) {
-                  
+
                   // temporary normalized magnitude of M_zface field at the fixed point
                   // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                   amrex::Real mag_normalized = std::sqrt( std::pow(M_zface(i, j, k, 0),2.0_rt) + std::pow(M_zface(i, j, k, 1),2.0_rt) +
@@ -590,7 +590,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
         }
 
         if (M_iter_maxerror <= M_tol) {
-            
+
             stop_iter = 1;
 
             // normalize M
@@ -621,7 +621,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
                         amrex::Real mag_normalized = std::sqrt( std::pow(M_xface(i, j, k, 0),2.0) + std::pow(M_xface(i, j, k, 1),2.0) +
                                                                 std::pow(M_xface(i, j, k, 2),2.0) )
                             / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
-                                           
+
                         // check the normalized error
                         if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
                             printf("i = %d, j=%d, k=%d\n", i, j, k);
@@ -635,7 +635,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
                     },
 
                     [=] AMREX_GPU_DEVICE (int i, int j, int k){
-                  
+
                         // temporary normalized magnitude of M_yface field at the fixed point
                         // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
                         amrex::Real mag_normalized = std::sqrt( std::pow(M_yface(i, j, k, 0),2.0) + std::pow(M_yface(i, j, k, 1),2.0) +
@@ -683,7 +683,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
                 Mfield_prev_max[i] = std::max(amrex::Math::abs((*Mfield_prev[i]).max(i,0)),amrex::Math::abs((*Mfield_prev[i]).min(i,0)));
             }
         }
-           
+
         if (M_iter >= M_max_iter) {
             amrex::Abort("The M_iter exceeds the M_max_iter");
             amrex::Print() << "The M_iter = " << M_iter << " exceeds the M_max_iter = " << M_max_iter << std::endl;
@@ -691,7 +691,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
             M_iter++;
             amrex::Print() << "Finish " << M_iter << " times iteration with M_iter_maxerror = " << M_iter_maxerror << " and M_tol = " << M_tol << std::endl;
         }
-    
+
     } // end the iteration
 }
 #endif

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
@@ -2,6 +2,7 @@
 blank
 */
 
+#include "WarpX.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "FiniteDifferenceSolver.H"
 #include "FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
@@ -49,6 +50,9 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
         // obtain the maximum relative amount we let M deviate from Ms before aborting
         amrex::Real mag_normalized_error = macroscopic_properties->getmag_normalized_error();
 
+        auto& warpx = WarpX::GetInstance();
+        int normalization_type = warpx.mag_secondorder_normalization;
+        
         // build temporary vector<multifab,3> Mfield_prev, Mfield_error, a_temp, a_temp_static, b_temp_static
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > Mfield_prev; // M^n before the iteration
         std::array< std::unique_ptr<amrex::MultiFab>, 3 > Mfield_error; // The error of the M field between the twoiterations
@@ -385,21 +389,25 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // z component on x-faces of grid
               M_xface(i, j, k, 2) = MacroscopicProperties::updateM_field(i, j, k, 2, a_temp_xface, b_temp_static_xface);
 
-              // temporary normalized magnitude of M_xface field at the fixed point
-              // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
-              amrex::Real mag_normalized = std::sqrt( std::pow(M_xface(i, j, k, 0),2.0) + std::pow(M_xface(i, j, k, 1),2.0) +
-                      std::pow(M_xface(i, j, k, 2),2.0) ) / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
+              if (normalization_type == 1) {
+              
+                  // temporary normalized magnitude of M_xface field at the fixed point
+                  // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
+                  amrex::Real mag_normalized = std::sqrt( std::pow(M_xface(i, j, k, 0),2.0) + std::pow(M_xface(i, j, k, 1),2.0) +
+                                                          std::pow(M_xface(i, j, k, 2),2.0) )
+                      / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
 
-              // check the normalized error
-              if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
-                  printf("i = %d, j=%d, k=%d\n", i, j, k);
-                  printf("mag_normalized = %f, mag_normalized_error=%f\n", mag_normalized, mag_normalized_error);
-                  amrex::Abort("Exceed the normalized error of the M_xface field");
+                  // check the normalized error
+                  if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
+                      printf("i = %d, j=%d, k=%d\n", i, j, k);
+                      printf("mag_normalized = %f, mag_normalized_error=%f\n", mag_normalized, mag_normalized_error);
+                      amrex::Abort("Exceed the normalized error of the M_xface field");
+                  }
+                  // normalize the M_xface field
+                  M_xface(i,j,k,0) /= mag_normalized;
+                  M_xface(i,j,k,1) /= mag_normalized;
+                  M_xface(i,j,k,2) /= mag_normalized;
               }
-              // normalize the M_xface field
-              M_xface(i,j,k,0) /= mag_normalized;
-              M_xface(i,j,k,1) /= mag_normalized;
-              M_xface(i,j,k,2) /= mag_normalized;
 
               // calculate M_error_xface
               // x component on x-faces of grid
@@ -460,21 +468,25 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // z component on y-faces of grid
               M_yface(i, j, k, 2) = MacroscopicProperties::updateM_field(i, j, k, 2, a_temp_yface, b_temp_static_yface);
 
-              // temporary normalized magnitude of M_yface field at the fixed point
-              // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
-              amrex::Real mag_normalized = std::sqrt( std::pow(M_yface(i, j, k, 0),2.0) + std::pow(M_yface(i, j, k, 1),2.0) +
-                      std::pow(M_yface(i, j, k, 2),2.0) ) / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_Ms_arr);
+              if (normalization_type == 1) {
+                  
+                  // temporary normalized magnitude of M_yface field at the fixed point
+                  // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
+                  amrex::Real mag_normalized = std::sqrt( std::pow(M_yface(i, j, k, 0),2.0) + std::pow(M_yface(i, j, k, 1),2.0) +
+                                                          std::pow(M_yface(i, j, k, 2),2.0) )
+                      / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_Ms_arr);
 
-              // check the normalized error
-              if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
-                 printf("i = %d, j=%d, k=%d\n", i, j, k);
-                 printf("mag_normalized = %f, mag_normalized_error=%f\n",mag_normalized, mag_normalized_error);
-                 amrex::Abort("Exceed the normalized error of the M_yface field");
+                  // check the normalized error
+                  if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
+                      printf("i = %d, j=%d, k=%d\n", i, j, k);
+                      printf("mag_normalized = %f, mag_normalized_error=%f\n",mag_normalized, mag_normalized_error);
+                      amrex::Abort("Exceed the normalized error of the M_yface field");
+                  }
+                  // normalize the M_yface field
+                  M_yface(i,j,k,0) /= mag_normalized;
+                  M_yface(i,j,k,1) /= mag_normalized;
+                  M_yface(i,j,k,2) /= mag_normalized;
               }
-              // normalize the M_yface field
-              M_yface(i,j,k,0) /= mag_normalized;
-              M_yface(i,j,k,1) /= mag_normalized;
-              M_yface(i,j,k,2) /= mag_normalized;
 
               // calculate M_error_yface
               // x component on y-faces of grid
@@ -534,21 +546,25 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // z component on z-faces of grid
               M_zface(i, j, k, 2) = MacroscopicProperties::updateM_field(i, j, k, 2, a_temp_zface, b_temp_static_zface);
 
-              // temporary normalized magnitude of M_zface field at the fixed point
-              // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
-              amrex::Real mag_normalized = std::sqrt( std::pow(M_zface(i, j, k, 0),2.0_rt) + std::pow(M_zface(i, j, k, 1),2.0_rt) +
-                      std::pow(M_zface(i, j, k, 2),2.0_rt) ) / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_Ms_arr);
+              if (normalization_type == 1) {
+                  
+                  // temporary normalized magnitude of M_zface field at the fixed point
+                  // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
+                  amrex::Real mag_normalized = std::sqrt( std::pow(M_zface(i, j, k, 0),2.0_rt) + std::pow(M_zface(i, j, k, 1),2.0_rt) +
+                                                          std::pow(M_zface(i, j, k, 2),2.0_rt) )
+                      / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_Ms_arr);
 
-              // check the normalized error
-              if ( amrex::Math::abs(1.-mag_normalized) > mag_normalized_error ){
-                 printf("i = %d, j=%d, k=%d\n", i, j, k);
-                 printf("mag_normalized = %f, mag_normalized_error=%f\n", mag_normalized, mag_normalized_error);
-                 amrex::Abort("Exceed the normalized error of the M_zface field");
+                  // check the normalized error
+                  if ( amrex::Math::abs(1.-mag_normalized) > mag_normalized_error ){
+                      printf("i = %d, j=%d, k=%d\n", i, j, k);
+                      printf("mag_normalized = %f, mag_normalized_error=%f\n", mag_normalized, mag_normalized_error);
+                      amrex::Abort("Exceed the normalized error of the M_zface field");
+                  }
+                  // normalize the M_zface field
+                  M_zface(i,j,k,0) /= mag_normalized;
+                  M_zface(i,j,k,1) /= mag_normalized;
+                  M_zface(i,j,k,2) /= mag_normalized;
               }
-              // normalize the M_zface field
-              M_zface(i,j,k,0) /= mag_normalized;
-              M_zface(i,j,k,1) /= mag_normalized;
-              M_zface(i,j,k,2) /= mag_normalized;
 
               // calculate M_error_zface
               // x component on z-faces of grid
@@ -573,26 +589,108 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
         }
 
         if (M_iter_maxerror <= M_tol) {
-           stop_iter = 1;
-        }
-        else {
-           // Copy Mfield to Mfield_previous and re-calculate Mfield_prev_max
-           for (int i = 0; i < 3; i++){
-               MultiFab::Copy(*Mfield_prev[i],*Mfield[i],0,0,3,Mfield[i]->nGrow());
-               Mfield_prev_max[i] = std::max(amrex::Math::abs((*Mfield_prev[i]).max(i,0)),amrex::Math::abs((*Mfield_prev[i]).min(i,0)));
-           }
-        }
+            
+            stop_iter = 1;
 
-        if(M_iter >= M_max_iter) {
-           amrex::Abort("The M_iter exceeds the M_max_iter");
-           amrex::Print() << "The M_iter = " << M_iter << " exceeds the M_max_iter = " << M_max_iter << std::endl;
-        }
-        else {
-           M_iter++;
-           amrex::Print() << "Finish " << M_iter << " times iteration with M_iter_maxerror = " << M_iter_maxerror << " and M_tol = " << M_tol << std::endl;
-        }
+            // normalize M
+            if (normalization_type == 2) {
 
+                for (MFIter mfi(*Mfield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    auto& mag_Ms_mf = macroscopic_properties->getmag_Ms_mf();
+                    // exctract material properties
+                    Array4<Real> const& mag_Ms_arr = mag_Ms_mf.array(mfi);
+
+                    // extract field data
+                    Array4<Real> const& M_xface = Mfield[0]->array(mfi); // note M_xface include x,y,z components at |_x faces
+                    Array4<Real> const& M_yface = Mfield[1]->array(mfi); // note M_yface include x,y,z components at |_y faces
+                    Array4<Real> const& M_zface = Mfield[2]->array(mfi); // note M_zface include x,y,z components at |_z faces
+
+                    // extract tileboxes for which to loop
+                    Box const& tbx = mfi.tilebox(Bfield[0]->ixType().toIntVect()); /* just define which grid type */
+                    Box const& tby = mfi.tilebox(Bfield[1]->ixType().toIntVect());
+                    Box const& tbz = mfi.tilebox(Bfield[2]->ixType().toIntVect());
+
+                    // loop over cells and update fields
+                    amrex::ParallelFor(tbx, tby, tbz,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+                        // temporary normalized magnitude of M_xface field at the fixed point
+                        // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
+                        amrex::Real mag_normalized = std::sqrt( std::pow(M_xface(i, j, k, 0),2.0) + std::pow(M_xface(i, j, k, 1),2.0) +
+                                                                std::pow(M_xface(i, j, k, 2),2.0) )
+                            / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(1,0,0),mag_Ms_arr);
+                                           
+                        // check the normalized error
+                        if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
+                            printf("i = %d, j=%d, k=%d\n", i, j, k);
+                            printf("mag_normalized = %f, mag_normalized_error=%f\n", mag_normalized, mag_normalized_error);
+                            amrex::Abort("Exceed the normalized error of the M_xface field");
+                        }
+                        // normalize the M_xface field
+                        M_xface(i,j,k,0) /= mag_normalized;
+                        M_xface(i,j,k,1) /= mag_normalized;
+                        M_xface(i,j,k,2) /= mag_normalized;
+                    },
+
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                  
+                        // temporary normalized magnitude of M_yface field at the fixed point
+                        // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
+                        amrex::Real mag_normalized = std::sqrt( std::pow(M_yface(i, j, k, 0),2.0) + std::pow(M_yface(i, j, k, 1),2.0) +
+                                                                std::pow(M_yface(i, j, k, 2),2.0) )
+                            / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,1,0),mag_Ms_arr);
+
+                        // check the normalized error
+                        if ( amrex::Math::abs(1._rt-mag_normalized) > mag_normalized_error ){
+                            printf("i = %d, j=%d, k=%d\n", i, j, k);
+                            printf("mag_normalized = %f, mag_normalized_error=%f\n",mag_normalized, mag_normalized_error);
+                            amrex::Abort("Exceed the normalized error of the M_yface field");
+                        }
+                        // normalize the M_yface field
+                        M_yface(i,j,k,0) /= mag_normalized;
+                        M_yface(i,j,k,1) /= mag_normalized;
+                        M_yface(i,j,k,2) /= mag_normalized;
+
+                    },
+
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+                        // temporary normalized magnitude of M_zface field at the fixed point
+                        // re-investigate the way we do Ms interp, in case we encounter the case where Ms changes across two adjacent cells that you are doing interp
+                        amrex::Real mag_normalized = std::sqrt( std::pow(M_zface(i, j, k, 0),2.0_rt) + std::pow(M_zface(i, j, k, 1),2.0_rt) +
+                                                                std::pow(M_zface(i, j, k, 2),2.0_rt) )
+                            / MacroscopicProperties::macro_avg_to_face(i,j,k,amrex::IntVect(0,0,1),mag_Ms_arr);
+
+                        // check the normalized error
+                        if ( amrex::Math::abs(1.-mag_normalized) > mag_normalized_error ){
+                            printf("i = %d, j=%d, k=%d\n", i, j, k);
+                            printf("mag_normalized = %f, mag_normalized_error=%f\n", mag_normalized, mag_normalized_error);
+                            amrex::Abort("Exceed the normalized error of the M_zface field");
+                        }
+                        // normalize the M_zface field
+                        M_zface(i,j,k,0) /= mag_normalized;
+                        M_zface(i,j,k,1) /= mag_normalized;
+                        M_zface(i,j,k,2) /= mag_normalized;
+                    });
+                }
+            }
+        } else {
+            // Copy Mfield to Mfield_previous and re-calculate Mfield_prev_max
+            for (int i = 0; i < 3; i++){
+                MultiFab::Copy(*Mfield_prev[i],*Mfield[i],0,0,3,Mfield[i]->nGrow());
+                Mfield_prev_max[i] = std::max(amrex::Math::abs((*Mfield_prev[i]).max(i,0)),amrex::Math::abs((*Mfield_prev[i]).min(i,0)));
+            }
         }
-        // end the iteration
-    }
+           
+        if (M_iter >= M_max_iter) {
+            amrex::Abort("The M_iter exceeds the M_max_iter");
+            amrex::Print() << "The M_iter = " << M_iter << " exceeds the M_max_iter = " << M_max_iter << std::endl;
+        } else {
+            M_iter++;
+            amrex::Print() << "Finish " << M_iter << " times iteration with M_iter_maxerror = " << M_iter_maxerror << " and M_tol = " << M_tol << std::endl;
+        }
+    
+    } // end the iteration
+}
 #endif

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveM_2nd.cpp
@@ -51,6 +51,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
         amrex::Real mag_normalized_error = macroscopic_properties->getmag_normalized_error();
 
         auto& warpx = WarpX::GetInstance();
+        int coupling = warpx.mag_LLG_coupling;
         int normalization_type = warpx.mag_secondorder_normalization;
         
         // build temporary vector<multifab,3> Mfield_prev, Mfield_error, a_temp, a_temp_static, b_temp_static
@@ -123,19 +124,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
               // Hy and Hz can be acquired by interpolation
 
-              // H_maxwell
-              Real Hx_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Bx_old, M_xface);
-              Real Hy_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), By_old, M_xface);
-              Real Hz_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Bz_old, M_xface);
-
               // H_bias
-              Real Hx_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Hx_bias);
-              Real Hy_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), Hy_bias);
-              Real Hz_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_xface + Hx_bias_xface;
-              Real Hy_eff = Hy_xface + Hy_bias_xface;
-              Real Hz_eff = Hz_xface + Hz_bias_xface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Bx_old, M_xface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), By_old, M_xface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Bz_old, M_xface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation
@@ -173,19 +174,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
               // Hy and Hz can be acquired by interpolation
 
-              // H_maxwell
-              Real Hx_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Bx_old, M_yface);
-              Real Hy_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), By_old, M_yface);
-              Real Hz_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Bz_old, M_yface);
-
               // H_bias
-              Real Hx_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Hx_bias);
-              Real Hy_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), Hy_bias);
-              Real Hz_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_yface + Hx_bias_yface;
-              Real Hy_eff = Hy_yface + Hy_bias_yface;
-              Real Hz_eff = Hz_yface + Hz_bias_yface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Bx_old, M_yface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), By_old, M_yface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Bz_old, M_yface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation
@@ -223,19 +224,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
               // Hy and Hz can be acquired by interpolation
 
-              // H_maxwell
-              Real Hx_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Bx_old, M_zface);
-              Real Hy_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), By_old, M_zface);
-              Real Hz_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Bz_old, M_zface);
-
               // H_bias
-              Real Hx_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Hx_bias);
-              Real Hy_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), Hy_bias);
-              Real Hz_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_zface + Hx_bias_zface;
-              Real Hy_eff = Hy_zface + Hy_bias_zface;
-              Real Hz_eff = Hz_zface + Hz_bias_zface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Bx_old, M_zface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), By_old, M_zface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Bz_old, M_zface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation
@@ -347,19 +348,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // when working on M_xface(i,j,k, 0:2) we have direct access to M_xface(i,j,k,0:2) and Hx(i,j,k)
               // Hy and Hz can be acquired by interpolation
 
-              // H_maxwell
-              Real Hx_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Bx, M_prev_xface);
-              Real Hy_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), By, M_prev_xface);
-              Real Hz_xface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Bz, M_prev_xface);
-
               // H_bias
-              Real Hx_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Hx_bias);
-              Real Hy_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), Hy_bias);
-              Real Hz_bias_xface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_xface + Hx_bias_xface;
-              Real Hy_eff = Hy_xface + Hy_bias_xface;
-              Real Hz_eff = Hz_xface + Hz_bias_xface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(1,0,0), Bx, M_prev_xface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(1,0,0), By, M_prev_xface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(1,0,0), Bz, M_prev_xface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation
@@ -426,19 +427,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // when working on M_yface(i,j,k,0:2) we have direct access to M_yface(i,j,k,0:2) and Hy(i,j,k)
               // Hy and Hz can be acquired by interpolation
 
-              // H_maxwell
-              Real Hx_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Bx, M_prev_yface);
-              Real Hy_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), By, M_prev_yface);
-              Real Hz_yface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Bz, M_prev_yface);
-
               // H_bias
-              Real Hx_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Hx_bias);
-              Real Hy_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), Hy_bias);
-              Real Hz_bias_yface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_yface + Hx_bias_yface;
-              Real Hy_eff = Hy_yface + Hy_bias_yface;
-              Real Hz_eff = Hz_yface + Hz_bias_yface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,1,0), Bx, M_prev_yface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,1,0), By, M_prev_yface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,1,0), Bz, M_prev_yface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation
@@ -504,19 +505,19 @@ void FiniteDifferenceSolver::MacroscopicEvolveM_2nd (
               // when working on M_zface(i,j,k,0:2) we have direct access to M_zface(i,j,k,0:2) and Hz(i,j,k)
               // Hy and Hz can be acquired by interpolation
 
-              // H_maxwell
-              Real Hx_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Bx, M_prev_zface);
-              Real Hy_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), By, M_prev_zface);
-              Real Hz_zface = MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Bz, M_prev_zface);
-
               // H_bias
-              Real Hx_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Hx_bias);
-              Real Hy_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), Hy_bias);
-              Real Hz_bias_zface = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Hz_bias);
-              // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
-              Real Hx_eff = Hx_zface + Hx_bias_zface;
-              Real Hy_eff = Hy_zface + Hy_bias_zface;
-              Real Hz_eff = Hz_zface + Hz_bias_zface;
+              Real Hx_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Hx_bias);
+              Real Hy_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), Hy_bias);
+              Real Hz_eff = MacroscopicProperties::face_avg_to_face(i, j, k, 0, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Hz_bias);
+
+              if (coupling == 1) {
+                  // H_eff = H_maxwell + H_bias + H_exchange + H_anisotropy ... (only the first two terms are considered here)
+
+                  // H_maxwell
+                  Hx_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 0, amrex::IntVect(1,0,0), amrex::IntVect(0,0,1), Bx, M_prev_zface);
+                  Hy_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 1, amrex::IntVect(0,1,0), amrex::IntVect(0,0,1), By, M_prev_zface);
+                  Hz_eff += MacroscopicProperties::getH_Maxwell(i, j, k, 2, amrex::IntVect(0,0,1), amrex::IntVect(0,0,1), Bz, M_prev_zface);
+              }
 
               // magnetic material properties mag_alpha and mag_Ms are defined at cell nodes
               // keep the interpolation

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -169,6 +169,11 @@ public:
     static int em_solver_medium;
     static int macroscopic_solver_algo;
 
+#ifdef WARPX_MAG_LLG
+    // second-order magnetization normalization strategy
+    int mag_secondorder_normalization = 1;
+#endif
+
 #ifdef WARPX_USE_PSATD
     // If true (overwritten by the user in the input file), the current correction
     // defined in equation (19) of https://doi.org/10.1016/j.jcp.2013.03.010 is applied
@@ -666,7 +671,7 @@ protected:
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;
-
+    
 private:
 
     // Singleton is used when the code is run from python

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -172,6 +172,8 @@ public:
 #ifdef WARPX_MAG_LLG
     // second-order magnetization normalization strategy
     int mag_secondorder_normalization = 1;
+    // turn on LLG + Maxwell coupling
+    int mag_LLG_coupling = 1;
 #endif
 
 #ifdef WARPX_USE_PSATD

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -671,7 +671,7 @@ protected:
 
     //! Delete level data.  Called by AmrCore::regrid.
     virtual void ClearLevel (int lev) final;
-    
+
 private:
 
     // Singleton is used when the code is run from python

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -560,7 +560,7 @@ WarpX::ReadParameters ()
         pp.query("mag_secondorder_normalization", mag_secondorder_normalization);
         // turn on LLG + Maxwell coupling
         pp.query("mag_LLG_coupling",mag_LLG_coupling);
-        
+
 #endif
 
 #ifdef WARPX_DIM_RZ

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -556,6 +556,8 @@ WarpX::ReadParameters ()
 #ifdef WARPX_MAG_LLG
         // Read the value of the time advancement scheme of M field
         pp.query("mag_time_scheme_order", mag_time_scheme_order);
+        // Read second-order magnetization normalization strategy
+        pp.query("mag_secondorder_normalization", mag_secondorder_normalization);
 #endif
 
 #ifdef WARPX_DIM_RZ

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -558,6 +558,9 @@ WarpX::ReadParameters ()
         pp.query("mag_time_scheme_order", mag_time_scheme_order);
         // Read second-order magnetization normalization strategy
         pp.query("mag_secondorder_normalization", mag_secondorder_normalization);
+        // turn on LLG + Maxwell coupling
+        pp.query("mag_LLG_coupling",mag_LLG_coupling);
+        
 #endif
 
 #ifdef WARPX_DIM_RZ


### PR DESCRIPTION
When to apply normalization in the second-order magnetization scheme. `mag_secondorder_normalization==1` applies it after each iteration; `mag_secondorder_normalization==2` applies it after the iterations have converged. This requires `USE_LLG=TRUE` in the GNUMakefile.

Turn on coupling of Maxwell solution to the LLG updates. `mag_LLG_coupling==1` enables, `mag_LLG_coupling=0` diables. This requires `USE_LLG=TRUE` in the GNUMakefile.

Also, included a 1 line fix for a bug where the CellCenterFunctor scomp option wasn't implemented correctly