### PR TITLE
Hard soft excitation flag

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -967,13 +967,13 @@ Laser initialization
     ``warpx.Bx_excitation_flag_function(x,y,z)``,
     ``warpx.By_excitation_flag_function(x,y,z)``,
     ``warpx.Bz_excitation_flag_function(x,y,z)``. This spatially varying function can be
-    set to have three values, namely -1, 0, or 1.
-    If the flag is set to -1 at a given `(x,y,z)`, then the excitation is not applied to the
+    set to have three values, namely 0, 1, or 2.
+    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is not applied to the
     field component at that location.
-    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is treated as a hard
+    If the flag is set to 1 at a given `(x,y,z)`, then the excitation is treated as a hard
     source and the field component at that location is set exactly equal to the value
     from the `excitation_grid_function` of the corresponding field component.
-    If the flag is set to 1, then the excittaion is treated as a soft source and the
+    If the flag is set to 2, then the excittaion is treated as a soft source and the
     field component is updated with the contribution from the `excitation_grid_function`
     of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.
@@ -992,13 +992,13 @@ Laser initialization
     ``warpx.Ex_excitation_flag_function(x,y,z)``,
     ``warpx.Ey_excitation_flag_function(x,y,z)``,
     ``warpx.Ez_excitation_flag_function(x,y,z)``. This spatially varying function can be
-    set to have three values, namely -1, 0, or 1.
-    If the flag is set to -1 at a given `(x,y,z)`, then the excitation is not applied to the
+    set to have three values, namely 0, 1, or 2.
+    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is not applied to the
     field component at that location.
-    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is treated as a hard
+    If the flag is set to 1 at a given `(x,y,z)`, then the excitation is treated as a hard
     source and the field component at that location is set exactly equal to the value
     from the `excitation_grid_function` of the corresponding field component.
-    If the flag is set to 1, then the excittaion is treated as a soft source and the
+    If the flag is set to 2, then the excittaion is treated as a soft source and the
     field component is updated with the contribution from the `excitation_grid_function`
     of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.
@@ -1017,13 +1017,13 @@ Laser initialization
     ``warpx.Hx_excitation_flag_function(x,y,z)``,
     ``warpx.Hy_excitation_flag_function(x,y,z)``,
     ``warpx.Hz_excitation_flag_function(x,y,z)``. This spatially varying function can be
-    set to have three values, namely -1, 0, or 1.
-    If the flag is set to -1 at a given `(x,y,z)`, then the excitation is not applied to the
+    set to have three values, namely 0, 1, or 2.
+    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is not applied to the
     field component at that location.
-    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is treated as a hard
+    If the flag is set to 1 at a given `(x,y,z)`, then the excitation is treated as a hard
     source and the field component at that location is set exactly equal to the value
     from the `excitation_grid_function` of the corresponding field component.
-    If the flag is set to 1, then the excittaion is treated as a soft source and the
+    If the flag is set to 2, then the excittaion is treated as a soft source and the
     field component is updated with the contribution from the `excitation_grid_function`
     of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.

--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -963,6 +963,19 @@ Laser initialization
     ``warpx.Bx_excitation_grid_function(x,y,z,t)``,
     ``warpx.By_excitation_grid_function(x,y,z,t)``,
     ``warpx.Bz_excitation_grid_function(x,y,z,t)`` to apply the external B-field on the grid.
+    Additionally, the option also requires a flag function to set the type of excitation,
+    ``warpx.Bx_excitation_flag_function(x,y,z)``,
+    ``warpx.By_excitation_flag_function(x,y,z)``,
+    ``warpx.Bz_excitation_flag_function(x,y,z)``. This spatially varying function can be
+    set to have three values, namely -1, 0, or 1.
+    If the flag is set to -1 at a given `(x,y,z)`, then the excitation is not applied to the
+    field component at that location.
+    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is treated as a hard
+    source and the field component at that location is set exactly equal to the value
+    from the `excitation_grid_function` of the corresponding field component.
+    If the flag is set to 1, then the excittaion is treated as a soft source and the
+    field component is updated with the contribution from the `excitation_grid_function`
+    of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.
     This function is currently supported only for 3D simulations.
 
@@ -975,6 +988,19 @@ Laser initialization
     ``warpx.Ex_excitation_grid_function(x,y,z,t)``,
     ``warpx.Ey_excitation_grid_function(x,y,z,t)``,
     ``warpx.Ez_excitation_grid_function(x,y,z,t)`` to apply the external E-field on the grid.
+    Additionally, the option also requires a flag function to set the type of excitation,
+    ``warpx.Ex_excitation_flag_function(x,y,z)``,
+    ``warpx.Ey_excitation_flag_function(x,y,z)``,
+    ``warpx.Ez_excitation_flag_function(x,y,z)``. This spatially varying function can be
+    set to have three values, namely -1, 0, or 1.
+    If the flag is set to -1 at a given `(x,y,z)`, then the excitation is not applied to the
+    field component at that location.
+    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is treated as a hard
+    source and the field component at that location is set exactly equal to the value
+    from the `excitation_grid_function` of the corresponding field component.
+    If the flag is set to 1, then the excittaion is treated as a soft source and the
+    field component is updated with the contribution from the `excitation_grid_function`
+    of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.
     This function is currently supported only for 3D simulations.
 
@@ -987,6 +1013,19 @@ Laser initialization
     ``warpx.Hx_excitation_grid_function(x,y,z,t)``,
     ``warpx.Hy_excitation_grid_function(x,y,z,t)``,
     ``warpx.Hz_excitation_grid_function(x,y,z,t)`` to apply the external H-field on the grid.
+    Additionally, the option also requires a flag function to set the type of excitation,
+    ``warpx.Hx_excitation_flag_function(x,y,z)``,
+    ``warpx.Hy_excitation_flag_function(x,y,z)``,
+    ``warpx.Hz_excitation_flag_function(x,y,z)``. This spatially varying function can be
+    set to have three values, namely -1, 0, or 1.
+    If the flag is set to -1 at a given `(x,y,z)`, then the excitation is not applied to the
+    field component at that location.
+    If the flag is set to 0 at a given `(x,y,z)`, then the excitation is treated as a hard
+    source and the field component at that location is set exactly equal to the value
+    from the `excitation_grid_function` of the corresponding field component.
+    If the flag is set to 1, then the excittaion is treated as a soft source and the
+    field component is updated with the contribution from the `excitation_grid_function`
+    of the corresponding field component.
     Constants required in the mathematical expression can be set using ``my_constants``.
     This function is currently supported only for 3D simulations.
     This requires `USE_LLG=TRUE` in the GNUMakefile.

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -102,7 +102,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfx_stag,
                                                   problo, dx, x, y, z);
                 auto flag_type = xflag_parser(x,y,z);
-                if ( flag_type >= 0 ) {
+                if ( flag_type >= 0._rt ) {
                     Fx(i, j, k) = Fx(i,j,k)*flag_type + xfield_parser(x,y,z,t);
                 }
             },
@@ -111,7 +111,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfy_stag,
                                                   problo, dx, x, y, z);
                 auto flag_type = yflag_parser(x,y,z);
-                if ( flag_type >= 0 ) {
+                if ( flag_type >= 0._rt ) {
                     Fy(i, j, k) = Fy(i,j,k)*flag_type + yfield_parser(x,y,z,t);
                 }
             },
@@ -121,7 +121,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                                                   problo, dx, x, y, z);
                 auto tmp_field_value = zfield_parser(x,y,z,t);
                 auto flag_type = zflag_parser(x,y,z);
-                if ( flag_type >= 0 ) {
+                if ( flag_type >= 0._rt ) {
                     Fz(i, j, k) = Fz(i,j,k)*flag_type + zfield_parser(x,y,z,t);
                 }
             }

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -96,10 +96,8 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                                                   problo, dx, x, y, z);
                 auto tmp_field_value = xfield_parser(x,y,z,t);
                 auto flag_type = xflag_parser(x,y,z);
-                if ( flag_type == 0 ) {
-                    Fx(i, j, k) += tmp_field_value;
-                } else if ( flag_type == 1 ) {
-                    Fx(i, j, k) = tmp_field_value;
+                if ( flag_type >= 0 ) {
+                    Fx(i, j, k) = Fx(i,j,k)*flag_type + tmp_field_value;
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
@@ -108,10 +106,8 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                                                   problo, dx, x, y, z);
                 auto tmp_field_value = yfield_parser(x,y,z,t);
                 auto flag_type = yflag_parser(x,y,z);
-                if ( flag_type == 0 ) {
-                    Fy(i, j, k) += tmp_field_value;
-                } else if ( flag_type == 1 ) {
-                    Fy(i, j, k) = tmp_field_value;
+                if ( flag_type >= 0 ) {
+                    Fy(i, j, k) = Fy(i,j,k)*flag_type + tmp_field_value;
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
@@ -120,10 +116,8 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                                                   problo, dx, x, y, z);
                 auto tmp_field_value = zfield_parser(x,y,z,t);
                 auto flag_type = zflag_parser(x,y,z);
-                if ( flag_type == 0 ) {
-                    Fz(i, j, k) += tmp_field_value;
-                } else if ( flag_type == 1 ) {
-                    Fz(i, j, k) = tmp_field_value;
+                if ( flag_type >= 0 ) {
+                    Fz(i, j, k) = Fz(i,j,k)*flag_type + tmp_field_value;
                 }
             }
         );

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -67,9 +67,10 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
 {
     // This function adds the contribution from an external excitation to the fields.
     // A flag is used to determine the type of excitation.
-    // If flag == 0, it is a hard source and the field = excitation
-    // If flag == 1, if is a soft source and the field += excitation
-    // If flag == -1, the excitation parser is not computed and the field is unchanged. 
+    // If flag == 1, it is a hard source and the field = excitation
+    // If flag == 2, if is a soft source and the field += excitation
+    // If flag == 0, the excitation parser is not computed and the field is unchanged. 
+    // If flag is not 0, or 1, or 2, the code will Abort!
 
     // Gpu vector to store Ex-Bz staggering (Hx-Hz for LLG)
     GpuArray<int,3> mfx_stag, mfy_stag, mfz_stag;
@@ -102,8 +103,10 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfx_stag,
                                                   problo, dx, x, y, z);
                 auto flag_type = xflag_parser(x,y,z);
-                if ( flag_type >= 0._rt ) {
-                    Fx(i, j, k) = Fx(i,j,k)*flag_type + xfield_parser(x,y,z,t);
+                if (flag_type != 0._rt || flag_type != 1._rt || flag_type != 2._rt) {
+                    amrex::Abort("flag type for excitation must be 0, or 1, or 2!");
+                } else if ( flag_type > 0._rt ) {
+                    Fx(i, j, k) = Fx(i,j,k)*(flag_type-1.0_rt) + xfield_parser(x,y,z,t);
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
@@ -111,8 +114,10 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfy_stag,
                                                   problo, dx, x, y, z);
                 auto flag_type = yflag_parser(x,y,z);
-                if ( flag_type >= 0._rt ) {
-                    Fy(i, j, k) = Fy(i,j,k)*flag_type + yfield_parser(x,y,z,t);
+                if (flag_type != 0._rt || flag_type != 1._rt || flag_type != 2._rt) {
+                    amrex::Abort("flag type for excitation must be 0, or 1, or 2!");
+                } else if ( flag_type > 0._rt ) {
+                    Fy(i, j, k) = Fy(i,j,k)*(flag_type-1.0_rt) + yfield_parser(x,y,z,t);
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
@@ -121,8 +126,10 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                                                   problo, dx, x, y, z);
                 auto tmp_field_value = zfield_parser(x,y,z,t);
                 auto flag_type = zflag_parser(x,y,z);
-                if ( flag_type >= 0._rt ) {
-                    Fz(i, j, k) = Fz(i,j,k)*flag_type + zfield_parser(x,y,z,t);
+                if (flag_type != 0._rt || flag_type != 1._rt || flag_type != 2._rt) {
+                    amrex::Abort("flag type for excitation must be 0, or 1, or 2!");
+                } else if ( flag_type > 0._rt ) {
+                    Fz(i, j, k) = Fz(i,j,k)*(flag_type-1.0_rt) + zfield_parser(x,y,z,t);
                 }
             }
         );

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -94,33 +94,36 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 amrex::Real x, y, z;
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfx_stag,
                                                   problo, dx, x, y, z);
-                if ( xflag_parser(x,y,z) == 0 ) {
-                    Fx(i, j, k) += xfield_parser(x, y, z, t);
-                }
-                if ( xflag_parser(x,y,z) == 1 ) {
-                    Fx(i, j, k) = xfield_parser(x, y, z, t);
+                auto tmp_field_value = xfield_parser(x,y,z,t);
+                auto flag_type = xflag_parser(x,y,z);
+                if ( flag_type == 0 ) {
+                    Fx(i, j, k) += tmp_field_value;
+                } else if ( flag_type == 1 ) {
+                    Fx(i, j, k) = tmp_field_value;
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 amrex::Real x, y, z;
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfy_stag,
                                                   problo, dx, x, y, z);
-                if ( yflag_parser(x,y,z) == 0 ) {
-                    Fy(i, j, k) += yfield_parser(x, y, z, t);
-                }
-                if ( yflag_parser(x,y,z) == 1 ) {
-                    Fy(i, j, k) = yfield_parser(x, y, z, t);
+                auto tmp_field_value = yfield_parser(x,y,z,t);
+                auto flag_type = yflag_parser(x,y,z);
+                if ( flag_type == 0 ) {
+                    Fy(i, j, k) += tmp_field_value;
+                } else if ( flag_type == 1 ) {
+                    Fy(i, j, k) = tmp_field_value;
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 amrex::Real x, y, z;
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfz_stag,
                                                   problo, dx, x, y, z);
-                if ( zflag_parser(x,y,z) == 0 ) {
-                    Fz(i, j, k) += zfield_parser(x, y, z, t);
-                }
-                if ( zflag_parser(x,y,z) == 1 ) {
-                    Fz(i, j, k) = zfield_parser(x, y, z, t);
+                auto tmp_field_value = zfield_parser(x,y,z,t);
+                auto flag_type = zflag_parser(x,y,z);
+                if ( flag_type == 0 ) {
+                    Fz(i, j, k) += tmp_field_value;
+                } else if ( flag_type == 1 ) {
+                    Fz(i, j, k) = tmp_field_value;
                 }
             }
         );

--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -103,7 +103,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfx_stag,
                                                   problo, dx, x, y, z);
                 auto flag_type = xflag_parser(x,y,z);
-                if (flag_type != 0._rt || flag_type != 1._rt || flag_type != 2._rt) {
+                if (flag_type != 0._rt && flag_type != 1._rt && flag_type != 2._rt) {
                     amrex::Abort("flag type for excitation must be 0, or 1, or 2!");
                 } else if ( flag_type > 0._rt ) {
                     Fx(i, j, k) = Fx(i,j,k)*(flag_type-1.0_rt) + xfield_parser(x,y,z,t);
@@ -114,7 +114,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                 WarpXUtilAlgo::getCellCoordinates(i, j, k, mfy_stag,
                                                   problo, dx, x, y, z);
                 auto flag_type = yflag_parser(x,y,z);
-                if (flag_type != 0._rt || flag_type != 1._rt || flag_type != 2._rt) {
+                if (flag_type != 0._rt && flag_type != 1._rt && flag_type != 2._rt) {
                     amrex::Abort("flag type for excitation must be 0, or 1, or 2!");
                 } else if ( flag_type > 0._rt ) {
                     Fy(i, j, k) = Fy(i,j,k)*(flag_type-1.0_rt) + yfield_parser(x,y,z,t);
@@ -126,7 +126,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
                                                   problo, dx, x, y, z);
                 auto tmp_field_value = zfield_parser(x,y,z,t);
                 auto flag_type = zflag_parser(x,y,z);
-                if (flag_type != 0._rt || flag_type != 1._rt || flag_type != 2._rt) {
+                if (flag_type != 0._rt && flag_type != 1._rt && flag_type != 2._rt) {
                     amrex::Abort("flag type for excitation must be 0, or 1, or 2!");
                 } else if ( flag_type > 0._rt ) {
                     Fz(i, j, k) = Fz(i,j,k)*(flag_type-1.0_rt) + zfield_parser(x,y,z,t);

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -329,7 +329,49 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                    H_excitation_grid_s.begin(),
                    ::tolower);
 #endif
-
+    std::vector<std::string> f;
+    if (pp.queryarr("Ex_excitation_flag_function(x,y,z)",f) ) {
+        Store_parserString(pp, "Ex_excitation_flag_function(x,y,z)",
+                                str_Ex_excitation_flag_function);
+    }
+    if (pp.queryarr("Ey_excitation_flag_function(x,y,z)",f) ) {
+        Store_parserString(pp, "Ey_excitation_flag_function(x,y,z)",
+                                str_Ey_excitation_flag_function);
+    }
+    if (pp.queryarr("Ez_excitation_flag_function(x,y,z)",f) ) {
+        Store_parserString(pp, "Ez_excitation_flag_function(x,y,z)",
+                                str_Ez_excitation_flag_function);
+    }
+    if (pp.queryarr("Bx_excitation_flag_function(x,y,z)",f) ) {
+        Store_parserString(pp, "Bx_excitation_flag_function(x,y,z)",
+                                str_Bx_excitation_flag_function);
+    }
+    if (pp.queryarr("By_excitation_flag_function(x,y,z)",f) ) {
+        Store_parserString(pp, "By_excitation_flag_function(x,y,z)",
+                                str_By_excitation_flag_function);
+    }
+    if (pp.queryarr("Bz_excitation_flag_function(x,y,z)",f) ) {
+        Store_parserString(pp, "Bz_excitation_flag_function(x,y,z)",
+                                str_Bz_excitation_flag_function);
+    }
+    Exfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Ex_excitation_flag_function,{"x","y","z"})));
+    Eyfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Ey_excitation_flag_function,{"x","y","z"})));
+    Ezfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Ez_excitation_flag_function,{"x","y","z"})));
+    Bxfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Bx_excitation_flag_function,{"x","y","z"})));
+    Byfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_By_excitation_flag_function,{"x","y","z"})));
+    Bzfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Bz_excitation_flag_function,{"x","y","z"})));
+    amrex::Print() << " Ex flag : " << str_Ex_excitation_flag_function << "\n";
+    amrex::Print() << " Ey flag : " << str_Ey_excitation_flag_function << "\n";
+    amrex::Print() << " Ez flag : " << str_Ez_excitation_flag_function << "\n";
+    amrex::Print() << " Bx flag : " << str_Bx_excitation_flag_function << "\n";
+    amrex::Print() << " By flag : " << str_By_excitation_flag_function << "\n";
+    amrex::Print() << " Bz flag : " << str_Bz_excitation_flag_function << "\n";
     // * Functions with the string "arr" in their names get an Array of
     //   values from the given entry in the table.  The array argument is
     //   resized (if necessary) to hold all the values requested.

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -366,12 +366,6 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         makeParser(str_By_excitation_flag_function,{"x","y","z"})));
     Bzfield_flag_parser.reset(new ParserWrapper<3>(
         makeParser(str_Bz_excitation_flag_function,{"x","y","z"})));
-    amrex::Print() << " Ex flag : " << str_Ex_excitation_flag_function << "\n";
-    amrex::Print() << " Ey flag : " << str_Ey_excitation_flag_function << "\n";
-    amrex::Print() << " Ez flag : " << str_Ez_excitation_flag_function << "\n";
-    amrex::Print() << " Bx flag : " << str_Bx_excitation_flag_function << "\n";
-    amrex::Print() << " By flag : " << str_By_excitation_flag_function << "\n";
-    amrex::Print() << " Bz flag : " << str_Bz_excitation_flag_function << "\n";
     // * Functions with the string "arr" in their names get an Array of
     //   values from the given entry in the table.  The array argument is
     //   resized (if necessary) to hold all the values requested.

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -378,13 +378,13 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                 str_Hy_excitation_flag_function);
         Store_parserString(pp, "Hz_excitation_flag_function(x,y,z)",
                                 str_Hz_excitation_flag_function);
-        Hxfield_flag_parser.reset(new ParserWrapper<3>(
-            makeParser(str_Hx_excitation_flag_function,{"x","y","z"})));
-        Hyfield_flag_parser.reset(new ParserWrapper<3>(
-            makeParser(str_Hy_excitation_flag_function,{"x","y","z"})));
-        Hzfield_flag_parser.reset(new ParserWrapper<3>(
-            makeParser(str_Hz_excitation_flag_function,{"x","y","z"})));
     }
+    Hxfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Hx_excitation_flag_function,{"x","y","z"})));
+    Hyfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Hy_excitation_flag_function,{"x","y","z"})));
+    Hzfield_flag_parser.reset(new ParserWrapper<3>(
+        makeParser(str_Hz_excitation_flag_function,{"x","y","z"})));
 #endif
     // * Functions with the string "arr" in their names get an Array of
     //   values from the given entry in the table.  The array argument is

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -329,28 +329,27 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                    H_excitation_grid_s.begin(),
                    ::tolower);
 #endif
-    std::vector<std::string> f;
-    if (pp.queryarr("Ex_excitation_flag_function(x,y,z)",f) ) {
+    if (E_excitation_grid_s == "parse_e_excitation_grid_function") {
+        // if E excitation type is set to parser then the corresponding
+        // source type (hard=0, soft=1) must be specified for all components
+        // using the flag function. Note that a flag value of -1 will not update
+        // the field with the excitation.
         Store_parserString(pp, "Ex_excitation_flag_function(x,y,z)",
                                 str_Ex_excitation_flag_function);
-    }
-    if (pp.queryarr("Ey_excitation_flag_function(x,y,z)",f) ) {
         Store_parserString(pp, "Ey_excitation_flag_function(x,y,z)",
                                 str_Ey_excitation_flag_function);
-    }
-    if (pp.queryarr("Ez_excitation_flag_function(x,y,z)",f) ) {
         Store_parserString(pp, "Ez_excitation_flag_function(x,y,z)",
                                 str_Ez_excitation_flag_function);
     }
-    if (pp.queryarr("Bx_excitation_flag_function(x,y,z)",f) ) {
+    if (B_excitation_grid_s == "parse_b_excitation_grid_function") {
+        // if B excitation type is set to parser then the corresponding
+        // source type (hard=0, soft=1) must be specified for all components
+        // using the flag function. Note that a flag value of -1 will not update
+        // the field with the excitation.
         Store_parserString(pp, "Bx_excitation_flag_function(x,y,z)",
                                 str_Bx_excitation_flag_function);
-    }
-    if (pp.queryarr("By_excitation_flag_function(x,y,z)",f) ) {
         Store_parserString(pp, "By_excitation_flag_function(x,y,z)",
                                 str_By_excitation_flag_function);
-    }
-    if (pp.queryarr("Bz_excitation_flag_function(x,y,z)",f) ) {
         Store_parserString(pp, "Bz_excitation_flag_function(x,y,z)",
                                 str_Bz_excitation_flag_function);
     }
@@ -366,6 +365,27 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         makeParser(str_By_excitation_flag_function,{"x","y","z"})));
     Bzfield_flag_parser.reset(new ParserWrapper<3>(
         makeParser(str_Bz_excitation_flag_function,{"x","y","z"})));
+
+#ifdef WARPX_MAG_LLG
+    if (H_excitation_grid_s == "parse_h_excitation_grid_function") {
+        // if H excitation type is set to parser then the corresponding
+        // source type (hard=0, soft=1) must be specified for all components
+        // using the flag function. Note that a flag value of -1 will not update
+        // the field with the excitation.
+        Store_parserString(pp, "Hx_excitation_flag_function(x,y,z)",
+                                str_Hx_excitation_flag_function);
+        Store_parserString(pp, "Hy_excitation_flag_function(x,y,z)",
+                                str_Hy_excitation_flag_function);
+        Store_parserString(pp, "Hz_excitation_flag_function(x,y,z)",
+                                str_Hz_excitation_flag_function);
+        Hxfield_flag_parser.reset(new ParserWrapper<3>(
+            makeParser(str_Hx_excitation_flag_function,{"x","y","z"})));
+        Hyfield_flag_parser.reset(new ParserWrapper<3>(
+            makeParser(str_Hy_excitation_flag_function,{"x","y","z"})));
+        Hzfield_flag_parser.reset(new ParserWrapper<3>(
+            makeParser(str_Hz_excitation_flag_function,{"x","y","z"})));
+    }
+#endif
     // * Functions with the string "arr" in their names get an Array of
     //   values from the given entry in the table.  The array argument is
     //   resized (if necessary) to hold all the values requested.

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -745,11 +745,11 @@ public:
      *   To ensure that the excitation is appropriately accounted for, a flag parser for
      *   each component of the field must be specified.
      *   The flag can have three values :
-     *       If flag_type == -1, field is not updated with external excitation
-     *       If flag_type ==  0, field is set equal to the
-     *                           external excitation (aka hard source)
-     *       If flag_type ==  1, field is updated to add the contribution from
-     *                           external excitation (aka soft source)
+     *       If flag_type == 0, field is not updated with external excitation
+     *       If flag_type == 1, field is set equal to the
+     *                          external excitation (aka hard source)
+     *       If flag_type == 2, field is updated to add the contribution from
+     *                          external excitation (aka soft source)
      *
      *   \param[in] mfx, mfy, mfz : The field component Multifabs to be updated with
      *                              the external excitation.

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -151,6 +151,13 @@ public:
     static std::string str_Hy_excitation_grid_function;
     static std::string str_Hz_excitation_grid_function;
 #endif
+    // Flag for type of excitation (hard/soft)
+    static std::string str_Ex_excitation_flag_function;
+    static std::string str_Ey_excitation_flag_function;
+    static std::string str_Ez_excitation_flag_function;
+    static std::string str_Bx_excitation_flag_function;
+    static std::string str_By_excitation_flag_function;
+    static std::string str_Bz_excitation_flag_function;
 
 #ifdef WARPX_MAG_LLG
     // Parser for H_external on the grid
@@ -191,6 +198,12 @@ public:
     std::unique_ptr<ParserWrapper<4> > Hyfield_xt_grid_parser;
     std::unique_ptr<ParserWrapper<4> > Hzfield_xt_grid_parser;
 #endif
+    std::unique_ptr<ParserWrapper<3> > Exfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Eyfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Ezfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Bxfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Byfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Bzfield_flag_parser;
 
 #ifdef WARPX_MAG_LLG
     // ParserWrapper for H_external on the grid
@@ -720,7 +733,10 @@ public:
          amrex::MultiFab *mfy, amrex::MultiFab *mfz,
          HostDeviceParser<4> const& xfield_parser,
          HostDeviceParser<4> const& yfield_parser,
-         HostDeviceParser<4> const& zfield_parser, const int lev );
+         HostDeviceParser<4> const& zfield_parser,
+         HostDeviceParser<3> const& xflag_parser,
+         HostDeviceParser<3> const& yflag_parser,
+         HostDeviceParser<3> const& zflag_parser, const int lev );
 
 protected:
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -158,6 +158,11 @@ public:
     static std::string str_Bx_excitation_flag_function;
     static std::string str_By_excitation_flag_function;
     static std::string str_Bz_excitation_flag_function;
+#ifdef WARPX_MAG_LLG
+    static std::string str_Hx_excitation_flag_function;
+    static std::string str_Hy_excitation_flag_function;
+    static std::string str_Hz_excitation_flag_function;
+#endif
 
 #ifdef WARPX_MAG_LLG
     // Parser for H_external on the grid
@@ -204,6 +209,11 @@ public:
     std::unique_ptr<ParserWrapper<3> > Bxfield_flag_parser;
     std::unique_ptr<ParserWrapper<3> > Byfield_flag_parser;
     std::unique_ptr<ParserWrapper<3> > Bzfield_flag_parser;
+#ifdef WARPX_MAG_LLG
+    std::unique_ptr<ParserWrapper<3> > Hxfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Hyfield_flag_parser;
+    std::unique_ptr<ParserWrapper<3> > Hzfield_flag_parser;
+#endif
 
 #ifdef WARPX_MAG_LLG
     // ParserWrapper for H_external on the grid
@@ -725,8 +735,31 @@ public:
      */
     void ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::LayoutData<amrex::Real> > >& costs);
 
-    /** \brief adds the contribution of user-defined external field-excitation
-     *   to Efield_fp and Bfield_fp.
+    /** \brief Adds the contribution of user-defined external field-excitation
+     *   to Efield, Bfield, and also Hfield if `USE_LLG=TRUE`.
+     *   Two types of excitation are supported, namely, hard source and soft source.
+     *   An excitation is called hard source if the field value is set exactly equal
+     *   to the excitation (similar to a Dirichlet boundary) (field = excitation).
+     *   An excitation is called soft source if the field value is updated by adding
+     *   to it the contribution from the externally applied excitation (field += excitation).
+     *   To ensure that the excitation is appropriately accounted for, a flag parser for
+     *   each component of the field must be specified.
+     *   The flag can have three values :
+     *       If flag_type == -1, field is not updated with external excitation
+     *       If flag_type ==  0, field is set equal to the
+     *                           external excitation (aka hard source)
+     *       If flag_type ==  1, field is updated to add the contribution from
+     *                           external excitation (aka soft source)
+     *
+     *   \param[in] mfx, mfy, mfz : The field component Multifabs to be updated with
+     *                              the external excitation.
+     *   \param[in] xfield_parser : external excitation for xcomponent of the field
+     *   \param[in] yfield_parser : external excitation for ycomponent of the field
+     *   \param[in] zfield_parser : external excitation for zcomponent of the field
+     *   \param[in] xflag_parser  : Type xfield excitation (hard source=0/soft source=1)
+     *   \param[in] yflag_parser  : Type yfield excitation (hard source=0/soft source=1)
+     *   \param[in] zflag_parser  : Type zfield excitation (hard source=0/soft source=1)
+     *   \param[in] lev           : level on which the excitation is applied.
      */
     void ApplyExternalFieldExcitationOnGrid ();
     void ApplyExternalFieldExcitationOnGrid ( amrex::MultiFab *mfx,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -86,17 +86,17 @@ std::string WarpX::str_Hx_excitation_grid_function;
 std::string WarpX::str_Hy_excitation_grid_function;
 std::string WarpX::str_Hz_excitation_grid_function;
 #endif
-// Flag for type of excitation -1=none, 0=hard, 1=soft
-std::string WarpX::str_Ex_excitation_flag_function = "-1.";
-std::string WarpX::str_Ey_excitation_flag_function = "-1.";
-std::string WarpX::str_Ez_excitation_flag_function = "-1.";
-std::string WarpX::str_Bx_excitation_flag_function = "-1.";
-std::string WarpX::str_By_excitation_flag_function = "-1.";
-std::string WarpX::str_Bz_excitation_flag_function = "-1.";
+// Flag for type of excitation 0=none, 1=hard, 2=soft
+std::string WarpX::str_Ex_excitation_flag_function;
+std::string WarpX::str_Ey_excitation_flag_function;
+std::string WarpX::str_Ez_excitation_flag_function;
+std::string WarpX::str_Bx_excitation_flag_function;
+std::string WarpX::str_By_excitation_flag_function;
+std::string WarpX::str_Bz_excitation_flag_function;
 #ifdef WARPX_MAG_LLG
-std::string WarpX::str_Hx_excitation_flag_function = "-1.";
-std::string WarpX::str_Hy_excitation_flag_function = "-1.";
-std::string WarpX::str_Hz_excitation_flag_function = "-1.";
+std::string WarpX::str_Hx_excitation_flag_function;
+std::string WarpX::str_Hy_excitation_flag_function;
+std::string WarpX::str_Hz_excitation_flag_function;
 #endif
 
 #ifdef WARPX_MAG_LLG

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -86,7 +86,7 @@ std::string WarpX::str_Hx_excitation_grid_function;
 std::string WarpX::str_Hy_excitation_grid_function;
 std::string WarpX::str_Hz_excitation_grid_function;
 #endif
-// Flag for type of excitation -1=none, 0=soft, 1=hard
+// Flag for type of excitation -1=none, 0=hard, 1=soft
 std::string WarpX::str_Ex_excitation_flag_function = "-1";
 std::string WarpX::str_Ey_excitation_flag_function = "-1";
 std::string WarpX::str_Ez_excitation_flag_function = "-1";

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -87,16 +87,16 @@ std::string WarpX::str_Hy_excitation_grid_function;
 std::string WarpX::str_Hz_excitation_grid_function;
 #endif
 // Flag for type of excitation -1=none, 0=hard, 1=soft
-std::string WarpX::str_Ex_excitation_flag_function = "-1";
-std::string WarpX::str_Ey_excitation_flag_function = "-1";
-std::string WarpX::str_Ez_excitation_flag_function = "-1";
-std::string WarpX::str_Bx_excitation_flag_function = "-1";
-std::string WarpX::str_By_excitation_flag_function = "-1";
-std::string WarpX::str_Bz_excitation_flag_function = "-1";
+std::string WarpX::str_Ex_excitation_flag_function = "-1.";
+std::string WarpX::str_Ey_excitation_flag_function = "-1.";
+std::string WarpX::str_Ez_excitation_flag_function = "-1.";
+std::string WarpX::str_Bx_excitation_flag_function = "-1.";
+std::string WarpX::str_By_excitation_flag_function = "-1.";
+std::string WarpX::str_Bz_excitation_flag_function = "-1.";
 #ifdef WARPX_MAG_LLG
-std::string WarpX::str_Hx_excitation_flag_function = "-1";
-std::string WarpX::str_Hy_excitation_flag_function = "-1";
-std::string WarpX::str_Hz_excitation_flag_function = "-1";
+std::string WarpX::str_Hx_excitation_flag_function = "-1.";
+std::string WarpX::str_Hy_excitation_flag_function = "-1.";
+std::string WarpX::str_Hz_excitation_flag_function = "-1.";
 #endif
 
 #ifdef WARPX_MAG_LLG

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -87,12 +87,12 @@ std::string WarpX::str_Hy_excitation_grid_function;
 std::string WarpX::str_Hz_excitation_grid_function;
 #endif
 // Flag for type of excitation -1=none, 0=soft, 1=hard
-std::string WarpX::str_Ex_excitation_flag_function = "0";
-std::string WarpX::str_Ey_excitation_flag_function = "0";
-std::string WarpX::str_Ez_excitation_flag_function = "0";
-std::string WarpX::str_Bx_excitation_flag_function = "0";
-std::string WarpX::str_By_excitation_flag_function = "0";
-std::string WarpX::str_Bz_excitation_flag_function = "0";
+std::string WarpX::str_Ex_excitation_flag_function = "-1";
+std::string WarpX::str_Ey_excitation_flag_function = "-1";
+std::string WarpX::str_Ez_excitation_flag_function = "-1";
+std::string WarpX::str_Bx_excitation_flag_function = "-1";
+std::string WarpX::str_By_excitation_flag_function = "-1";
+std::string WarpX::str_Bz_excitation_flag_function = "-1";
 
 #ifdef WARPX_MAG_LLG
 // Parser for M_external on the grid

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -93,6 +93,11 @@ std::string WarpX::str_Ez_excitation_flag_function = "-1";
 std::string WarpX::str_Bx_excitation_flag_function = "-1";
 std::string WarpX::str_By_excitation_flag_function = "-1";
 std::string WarpX::str_Bz_excitation_flag_function = "-1";
+#ifdef WARPX_MAG_LLG
+std::string WarpX::str_Hx_excitation_flag_function = "-1";
+std::string WarpX::str_Hy_excitation_flag_function = "-1";
+std::string WarpX::str_Hz_excitation_flag_function = "-1";
+#endif
 
 #ifdef WARPX_MAG_LLG
 // Parser for M_external on the grid

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -86,6 +86,13 @@ std::string WarpX::str_Hx_excitation_grid_function;
 std::string WarpX::str_Hy_excitation_grid_function;
 std::string WarpX::str_Hz_excitation_grid_function;
 #endif
+// Flag for type of excitation (hard/soft)
+std::string WarpX::str_Ex_excitation_flag_function = "0";
+std::string WarpX::str_Ey_excitation_flag_function = "0";
+std::string WarpX::str_Ez_excitation_flag_function = "0";
+std::string WarpX::str_Bx_excitation_flag_function = "0";
+std::string WarpX::str_By_excitation_flag_function = "0";
+std::string WarpX::str_Bz_excitation_flag_function = "0";
 
 #ifdef WARPX_MAG_LLG
 // Parser for M_external on the grid

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -86,7 +86,7 @@ std::string WarpX::str_Hx_excitation_grid_function;
 std::string WarpX::str_Hy_excitation_grid_function;
 std::string WarpX::str_Hz_excitation_grid_function;
 #endif
-// Flag for type of excitation (hard/soft)
+// Flag for type of excitation -1=none, 0=soft, 1=hard
 std::string WarpX::str_Ex_excitation_flag_function = "0";
 std::string WarpX::str_Ey_excitation_flag_function = "0";
 std::string WarpX::str_Ez_excitation_flag_function = "0";


### PR DESCRIPTION
This PR adds the capability to either set the field value using the external excitation, called hard source
or add the external excitation on top of the self-consistent field, called soft source.
To do this, first a flag parser is used that spatially sets the type of excitation (hard=0/soft=1) for each field component
Then based on the value of the flag for a given (x,y,z), the external field is applied at that location.
The code will abort if the flag function is not specified for an external excitation read in using the parser.

I used the attached input file to test the implementation for USE_LLG=FALSE.

Verification test : 
Attached is an input file used to test the implementation.
An E-field excitation is added with corresponding flag types
```
my_constants.flag_none = -1
my_constants.flag_hs = 0
my_constants.flag_ss = 1
warpx.E_ext_grid_init_style = parse_E_ext_grid_function
warpx.Ex_external_grid_function(x,y,z) = "10.0"
warpx.Ey_external_grid_function(x,y,z) = "10.0"
warpx.Ez_external_grid_function(x,y,z) = "10.0"
warpx.E_excitation_on_grid_style = "parse_E_excitation_grid_function"
warpx.Ex_excitation_grid_function(x,y,z,t) = "0.0"
warpx.Ey_excitation_grid_function(x,y,z,t) = "100*(z<z0)+ 50*(z>=z0)"
warpx.Ez_excitation_grid_function(x,y,z,t) = "50.0"
warpx.Ex_excitation_flag_function(x,y,z) = "flag_none"
warpx.Ey_excitation_flag_function(x,y,z) = "flag_hs*(z<z0) + flag_ss*(z>=z0)"
warpx.Ez_excitation_flag_function(x,y,z) = "flag_ss"
```
I turned off the Maxwell solver in the code and initialized all the E-field components to have a value of 10 V/m and ran the simulation for two timesteps,

At the end of the two timesteps, ideally, Ex everywhere should be equal to 10 V/m and the plot below confirms that.
![Screenshot from 2020-10-20 16-44-09](https://user-images.githubusercontent.com/41089244/96655909-86a14180-12f3-11eb-8bde-a91ab79c2334.png)

Ez should be 10 + 50 + 50 = 110 V/m everywhere.
![Screenshot from 2020-10-20 16-45-44](https://user-images.githubusercontent.com/41089244/96655990-bfd9b180-12f3-11eb-9e50-d3433f57ec89.png)





Finally for Ey : for z < 0, the value should be strictly 100 and z>=0, the value should be 10 + 50 + 50 = 110.
At z==0 because the plotfiles are cell-centered and it take the average of the adjacent edge-based Ey values, the value is 105.
(This is only for the diagnostic and not the raw data)
![Screenshot from 2020-10-20 16-48-18](https://user-images.githubusercontent.com/41089244/96656245-4098ad80-12f4-11eb-840f-8af43fc08c7b.png)


[inputs_3d_test_flag.txt](https://github.com/RevathiJambunathan/WarpX/files/5412234/inputs_3d_test_flag.txt)