### PR TITLE
Don't read in the excitation flag functions unless we need them

### DIFF
--- a/Source/FieldSolver/WarpXExternalEMFields.cpp
+++ b/Source/FieldSolver/WarpXExternalEMFields.cpp
@@ -69,7 +69,7 @@ WarpX::ApplyExternalFieldExcitationOnGrid (
     // A flag is used to determine the type of excitation.
     // If flag == 1, it is a hard source and the field = excitation
     // If flag == 2, if is a soft source and the field += excitation
-    // If flag == 0, the excitation parser is not computed and the field is unchanged. 
+    // If flag == 0, the excitation parser is not computed and the field is unchanged.
     // If flag is not 0, or 1, or 2, the code will Abort!
 
     // Gpu vector to store Ex-Bz staggering (Hx-Hz for LLG)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -344,6 +344,12 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                 str_Ey_excitation_flag_function);
         Store_parserString(pp, "Ez_excitation_flag_function(x,y,z)",
                                 str_Ez_excitation_flag_function);
+        Exfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Ex_excitation_flag_function,{"x","y","z"})));
+        Eyfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Ey_excitation_flag_function,{"x","y","z"})));
+        Ezfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Ez_excitation_flag_function,{"x","y","z"})));
     }
     if (B_excitation_grid_s == "parse_b_excitation_grid_function") {
         // if B excitation type is set to parser then the corresponding
@@ -356,19 +362,13 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                 str_By_excitation_flag_function);
         Store_parserString(pp, "Bz_excitation_flag_function(x,y,z)",
                                 str_Bz_excitation_flag_function);
+        Bxfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Bx_excitation_flag_function,{"x","y","z"})));
+        Byfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_By_excitation_flag_function,{"x","y","z"})));
+        Bzfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Bz_excitation_flag_function,{"x","y","z"})));
     }
-    Exfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Ex_excitation_flag_function,{"x","y","z"})));
-    Eyfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Ey_excitation_flag_function,{"x","y","z"})));
-    Ezfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Ez_excitation_flag_function,{"x","y","z"})));
-    Bxfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Bx_excitation_flag_function,{"x","y","z"})));
-    Byfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_By_excitation_flag_function,{"x","y","z"})));
-    Bzfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Bz_excitation_flag_function,{"x","y","z"})));
 
 #ifdef WARPX_MAG_LLG
     if (H_excitation_grid_s == "parse_h_excitation_grid_function") {
@@ -382,13 +382,13 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                 str_Hy_excitation_flag_function);
         Store_parserString(pp, "Hz_excitation_flag_function(x,y,z)",
                                 str_Hz_excitation_flag_function);
+        Hxfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Hx_excitation_flag_function,{"x","y","z"})));
+        Hyfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Hy_excitation_flag_function,{"x","y","z"})));
+        Hzfield_flag_parser.reset(new ParserWrapper<3>(
+                   makeParser(str_Hz_excitation_flag_function,{"x","y","z"})));
     }
-    Hxfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Hx_excitation_flag_function,{"x","y","z"})));
-    Hyfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Hy_excitation_flag_function,{"x","y","z"})));
-    Hzfield_flag_parser.reset(new ParserWrapper<3>(
-        makeParser(str_Hz_excitation_flag_function,{"x","y","z"})));
 #endif
     // * Functions with the string "arr" in their names get an Array of
     //   values from the given entry in the table.  The array argument is


### PR DESCRIPTION
Fix the logic so the code doesn't read in the flag parser unless you state you are using a parsed excitation function.