### PR TITLE
Fix GPU compilation for averaging parsed M to faces

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -874,41 +874,43 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 }
 
 #ifdef WARPX_MAG_LLG
-void WarpX::AverageParsedMtoFaces(MultiFab& Mx, MultiFab& My, MultiFab& Mz,
-                                  MultiFab& Mxfield_face,
-                                  MultiFab& Myfield_face,
-                                  MultiFab& Mzfield_face)
+void WarpX::AverageParsedMtoFaces(MultiFab& Mx_cc,
+                                  MultiFab& My_cc,
+                                  MultiFab& Mz_cc,
+                                  MultiFab& Mx_face,
+                                  MultiFab& My_face,
+                                  MultiFab& Mz_face)
 {
     // average Mx, My, Mz to faces
-    for (MFIter mfi(Mxfield_face, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(Mx_face, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-        const amrex::Box& tbx = mfi.tilebox( IntVect(1,0,0), Mxfield_face.nGrowVect() );
-        const amrex::Box& tby = mfi.tilebox( IntVect(0,1,0), Myfield_face.nGrowVect() );
-        const amrex::Box& tbz = mfi.tilebox( IntVect(0,0,1), Mzfield_face.nGrowVect() );
+        const amrex::Box& tbx = mfi.tilebox( IntVect(1,0,0), Mx_face.nGrowVect() );
+        const amrex::Box& tby = mfi.tilebox( IntVect(0,1,0), My_face.nGrowVect() );
+        const amrex::Box& tbz = mfi.tilebox( IntVect(0,0,1), Mz_face.nGrowVect() );
 
-        auto const& mx_cc = Mx.array(mfi);
-        auto const& my_cc = My.array(mfi);
-        auto const& mz_cc = Mz.array(mfi);
+        auto const& mx_cc = Mx_cc.array(mfi);
+        auto const& my_cc = My_cc.array(mfi);
+        auto const& mz_cc = Mz_cc.array(mfi);
 
-        auto const& m_xface = Mxfield_face.array(mfi);
-        auto const& m_yface = Myfield_face.array(mfi);
-        auto const& m_zface = Mzfield_face.array(mfi);
+        auto const& mx_face = Mx_face.array(mfi);
+        auto const& my_face = My_face.array(mfi);
+        auto const& mz_face = Mz_face.array(mfi);
 
         amrex::ParallelFor (tbx, tby, tbz,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-            m_xface(i,j,k,0) = 0.5*(mx_cc(i-1,j,k) + mx_cc(i,j,k));
-            m_xface(i,j,k,1) = 0.5*(my_cc(i-1,j,k) + my_cc(i,j,k));
-            m_xface(i,j,k,2) = 0.5*(mz_cc(i-1,j,k) + mz_cc(i,j,k));
+            mx_face(i,j,k,0) = 0.5*(mx_cc(i-1,j,k) + mx_cc(i,j,k));
+            mx_face(i,j,k,1) = 0.5*(my_cc(i-1,j,k) + my_cc(i,j,k));
+            mx_face(i,j,k,2) = 0.5*(mz_cc(i-1,j,k) + mz_cc(i,j,k));
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-            m_yface(i,j,k,0) = 0.5*(mx_cc(i,j-1,k) + mx_cc(i,j,k));
-            m_yface(i,j,k,1) = 0.5*(my_cc(i,j-1,k) + my_cc(i,j,k));
-            m_yface(i,j,k,2) = 0.5*(mz_cc(i,j-1,k) + mz_cc(i,j,k));
+            my_face(i,j,k,0) = 0.5*(mx_cc(i,j-1,k) + mx_cc(i,j,k));
+            my_face(i,j,k,1) = 0.5*(my_cc(i,j-1,k) + my_cc(i,j,k));
+            my_face(i,j,k,2) = 0.5*(mz_cc(i,j-1,k) + mz_cc(i,j,k));
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-            m_zface(i,j,k,0) = 0.5*(mx_cc(i,j,k-1) + mx_cc(i,j,k));
-            m_zface(i,j,k,1) = 0.5*(my_cc(i,j,k-1) + my_cc(i,j,k));
-            m_zface(i,j,k,2) = 0.5*(mz_cc(i,j,k-1) + mz_cc(i,j,k));
+            mz_face(i,j,k,0) = 0.5*(mx_cc(i,j,k-1) + mx_cc(i,j,k));
+            mz_face(i,j,k,1) = 0.5*(my_cc(i,j,k-1) + my_cc(i,j,k));
+            mz_face(i,j,k,2) = 0.5*(mz_cc(i,j,k-1) + mz_cc(i,j,k));
         });
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -804,38 +804,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                                       getParser(Mzfield_parser),
                                                       lev);
 
-            // average Mx, My, Mz to faces in Mfield_fp
-            for (MFIter mfi(*Mfield_fp[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-
-                const amrex::Box& tbx = mfi.tilebox( IntVect(1,0,0), Mfield_fp[lev][0]->nGrowVect() );
-                const amrex::Box& tby = mfi.tilebox( IntVect(0,1,0), Mfield_fp[lev][1]->nGrowVect() );
-                const amrex::Box& tbz = mfi.tilebox( IntVect(0,0,1), Mfield_fp[lev][2]->nGrowVect() );
-
-                auto const& mx_cc = Mx.array(mfi);
-                auto const& my_cc = My.array(mfi);
-                auto const& mz_cc = Mz.array(mfi);
-
-                auto const& m_xface = Mfield_fp[lev][0]->array(mfi);
-                auto const& m_yface = Mfield_fp[lev][1]->array(mfi);
-                auto const& m_zface = Mfield_fp[lev][2]->array(mfi);
-
-                amrex::ParallelFor (tbx, tby, tbz,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    m_xface(i,j,k,0) = 0.5*(mx_cc(i-1,j,k) + mx_cc(i,j,k));
-                    m_xface(i,j,k,1) = 0.5*(my_cc(i-1,j,k) + my_cc(i,j,k));
-                    m_xface(i,j,k,2) = 0.5*(mz_cc(i-1,j,k) + mz_cc(i,j,k));
-                },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    m_yface(i,j,k,0) = 0.5*(mx_cc(i,j-1,k) + mx_cc(i,j,k));
-                    m_yface(i,j,k,1) = 0.5*(my_cc(i,j-1,k) + my_cc(i,j,k));
-                    m_yface(i,j,k,2) = 0.5*(mz_cc(i,j-1,k) + mz_cc(i,j,k));
-                },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    m_zface(i,j,k,0) = 0.5*(mx_cc(i,j,k-1) + mx_cc(i,j,k));
-                    m_zface(i,j,k,1) = 0.5*(my_cc(i,j,k-1) + my_cc(i,j,k));
-                    m_zface(i,j,k,2) = 0.5*(mz_cc(i,j,k-1) + mz_cc(i,j,k));
-                });
-            }
+            AverageParsedMtoFaces(Mx,My,Mz,*Mfield_fp[lev][0],*Mfield_fp[lev][1],*Mfield_fp[lev][2]);
         }
 
         if (lev > 0) {
@@ -855,38 +824,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                                           getParser(Mzfield_parser),
                                                           lev);
 
-                // average Mx, My, Mz to faces in Mfield_aux
-                for (MFIter mfi(*Mfield_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-
-                    const amrex::Box& tbx = mfi.tilebox( IntVect(1,0,0), Mfield_aux[lev][0]->nGrowVect() );
-                    const amrex::Box& tby = mfi.tilebox( IntVect(0,1,0), Mfield_aux[lev][1]->nGrowVect() );
-                    const amrex::Box& tbz = mfi.tilebox( IntVect(0,0,1), Mfield_aux[lev][2]->nGrowVect() );
-
-                    auto const& mx_cc = Mx.array(mfi);
-                    auto const& my_cc = My.array(mfi);
-                    auto const& mz_cc = Mz.array(mfi);
-
-                    auto const& m_xface = Mfield_aux[lev][0]->array(mfi);
-                    auto const& m_yface = Mfield_aux[lev][1]->array(mfi);
-                    auto const& m_zface = Mfield_aux[lev][2]->array(mfi);
-
-                    amrex::ParallelFor (tbx, tby, tbz,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        m_xface(i,j,k,0) = 0.5*(mx_cc(i-1,j,k) + mx_cc(i,j,k));
-                        m_xface(i,j,k,1) = 0.5*(my_cc(i-1,j,k) + my_cc(i,j,k));
-                        m_xface(i,j,k,2) = 0.5*(mz_cc(i-1,j,k) + mz_cc(i,j,k));
-                    },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        m_yface(i,j,k,0) = 0.5*(mx_cc(i,j-1,k) + mx_cc(i,j,k));
-                        m_yface(i,j,k,1) = 0.5*(my_cc(i,j-1,k) + my_cc(i,j,k));
-                        m_yface(i,j,k,2) = 0.5*(mz_cc(i,j-1,k) + mz_cc(i,j,k));
-                    },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        m_zface(i,j,k,0) = 0.5*(mx_cc(i,j,k-1) + mx_cc(i,j,k));
-                        m_zface(i,j,k,1) = 0.5*(my_cc(i,j,k-1) + my_cc(i,j,k));
-                        m_zface(i,j,k,2) = 0.5*(mz_cc(i,j,k-1) + mz_cc(i,j,k));
-                    });
-                }
+                AverageParsedMtoFaces(Mx,My,Mz,*Mfield_aux[lev][0],*Mfield_aux[lev][1],*Mfield_aux[lev][2]);
             }
 
             {   // use this brace so Mx, My, Mz go out of scope
@@ -905,38 +843,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                                                           getParser(Mzfield_parser),
                                                           lev);
 
-                // average Mx, My, Mz to faces in Mfield_cp
-                for (MFIter mfi(*Mfield_cp[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-
-                    const amrex::Box& tbx = mfi.tilebox( IntVect(1,0,0), Mfield_cp[lev][0]->nGrowVect() );
-                    const amrex::Box& tby = mfi.tilebox( IntVect(0,1,0), Mfield_cp[lev][1]->nGrowVect() );
-                    const amrex::Box& tbz = mfi.tilebox( IntVect(0,0,1), Mfield_cp[lev][2]->nGrowVect() );
-
-                    auto const& mx_cc = Mx.array(mfi);
-                    auto const& my_cc = My.array(mfi);
-                    auto const& mz_cc = Mz.array(mfi);
-
-                    auto const& m_xface = Mfield_cp[lev][0]->array(mfi);
-                    auto const& m_yface = Mfield_cp[lev][1]->array(mfi);
-                    auto const& m_zface = Mfield_cp[lev][2]->array(mfi);
-
-                    amrex::ParallelFor (tbx, tby, tbz,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        m_xface(i,j,k,0) = 0.5*(mx_cc(i-1,j,k) + mx_cc(i,j,k));
-                        m_xface(i,j,k,1) = 0.5*(my_cc(i-1,j,k) + my_cc(i,j,k));
-                        m_xface(i,j,k,2) = 0.5*(mz_cc(i-1,j,k) + mz_cc(i,j,k));
-                    },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        m_yface(i,j,k,0) = 0.5*(mx_cc(i,j-1,k) + mx_cc(i,j,k));
-                        m_yface(i,j,k,1) = 0.5*(my_cc(i,j-1,k) + my_cc(i,j,k));
-                        m_yface(i,j,k,2) = 0.5*(mz_cc(i,j-1,k) + mz_cc(i,j,k));
-                    },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        m_zface(i,j,k,0) = 0.5*(mx_cc(i,j,k-1) + mx_cc(i,j,k));
-                        m_zface(i,j,k,1) = 0.5*(my_cc(i,j,k-1) + my_cc(i,j,k));
-                        m_zface(i,j,k,2) = 0.5*(mz_cc(i,j,k-1) + mz_cc(i,j,k));
-                    });
-                }
+                AverageParsedMtoFaces(Mx,My,Mz,*Mfield_cp[lev][0],*Mfield_cp[lev][1],*Mfield_cp[lev][2]);
             }
         }
     }
@@ -965,6 +872,47 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         }
     }
 }
+
+#ifdef WARPX_MAG_LLG
+void WarpX::AverageParsedMtoFaces(MultiFab& Mx, MultiFab& My, MultiFab& Mz,
+                                  MultiFab& Mxfield_face,
+                                  MultiFab& Myfield_face,
+                                  MultiFab& Mzfield_face)
+{
+    // average Mx, My, Mz to faces
+    for (MFIter mfi(Mxfield_face, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+
+        const amrex::Box& tbx = mfi.tilebox( IntVect(1,0,0), Mxfield_face.nGrowVect() );
+        const amrex::Box& tby = mfi.tilebox( IntVect(0,1,0), Myfield_face.nGrowVect() );
+        const amrex::Box& tbz = mfi.tilebox( IntVect(0,0,1), Mzfield_face.nGrowVect() );
+
+        auto const& mx_cc = Mx.array(mfi);
+        auto const& my_cc = My.array(mfi);
+        auto const& mz_cc = Mz.array(mfi);
+
+        auto const& m_xface = Mxfield_face.array(mfi);
+        auto const& m_yface = Myfield_face.array(mfi);
+        auto const& m_zface = Mzfield_face.array(mfi);
+
+        amrex::ParallelFor (tbx, tby, tbz,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            m_xface(i,j,k,0) = 0.5*(mx_cc(i-1,j,k) + mx_cc(i,j,k));
+            m_xface(i,j,k,1) = 0.5*(my_cc(i-1,j,k) + my_cc(i,j,k));
+            m_xface(i,j,k,2) = 0.5*(mz_cc(i-1,j,k) + mz_cc(i,j,k));
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            m_yface(i,j,k,0) = 0.5*(mx_cc(i,j-1,k) + mx_cc(i,j,k));
+            m_yface(i,j,k,1) = 0.5*(my_cc(i,j-1,k) + my_cc(i,j,k));
+            m_yface(i,j,k,2) = 0.5*(mz_cc(i,j-1,k) + mz_cc(i,j,k));
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            m_zface(i,j,k,0) = 0.5*(mx_cc(i,j,k-1) + mx_cc(i,j,k));
+            m_zface(i,j,k,1) = 0.5*(my_cc(i,j,k-1) + my_cc(i,j,k));
+            m_zface(i,j,k,2) = 0.5*(mz_cc(i,j,k-1) + mz_cc(i,j,k));
+        });
+    }
+}
+#endif
 
 void
 WarpX::InitializeExternalFieldsOnGridUsingParser (

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -776,6 +776,13 @@ public:
          HostDeviceParser<3> const& yflag_parser,
          HostDeviceParser<3> const& zflag_parser, const int lev );
 
+#ifdef WARPX_MAG_LLG
+    void AverageParsedMtoFaces(amrex::MultiFab& Mx, amrex::MultiFab& My, amrex::MultiFab& Mz,
+                               amrex::MultiFab& Mxfield_face,
+                               amrex::MultiFab& Myfield_face,
+                               amrex::MultiFab& Mzfield_face);
+#endif
+
 protected:
 
     /**

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -777,10 +777,12 @@ public:
          HostDeviceParser<3> const& zflag_parser, const int lev );
 
 #ifdef WARPX_MAG_LLG
-    void AverageParsedMtoFaces(amrex::MultiFab& Mx, amrex::MultiFab& My, amrex::MultiFab& Mz,
-                               amrex::MultiFab& Mxfield_face,
-                               amrex::MultiFab& Myfield_face,
-                               amrex::MultiFab& Mzfield_face);
+    void AverageParsedMtoFaces(amrex::MultiFab& Mx_cc,
+                               amrex::MultiFab& My_cc,
+                               amrex::MultiFab& Mz_cc,
+                               amrex::MultiFab& Mx_face,
+                               amrex::MultiFab& My_face,
+                               amrex::MultiFab& Mz_face);
 #endif
 
 protected:


### PR DESCRIPTION
Fix GPU compilation for averaging parsed M to faces by making a public function in WarpX to allow access to the protected Mfield data members.

