### PR TITLE
Macroscopic pml

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -107,7 +107,8 @@ public:
          int do_dive_cleaning, int do_moving_window,
          int pml_has_particles, int do_pml_in_domain,
          const amrex::IntVect do_pml_Lo = amrex::IntVect::TheUnitVector(),
-         const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector());
+         const amrex::IntVect do_pml_Hi = amrex::IntVect::TheUnitVector(),
+         const int lev = 0);
 
     void ComputePMLFactors (amrex::Real dt);
 
@@ -124,6 +125,14 @@ public:
 
     amrex::MultiFab* GetF_fp ();
     amrex::MultiFab* GetF_cp ();
+
+    // return macroscopic pml multifabs
+    amrex::MultiFab* Geteps_fp();
+    amrex::MultiFab* Geteps_cp();
+    amrex::MultiFab* Getmu_fp();
+    amrex::MultiFab* Getmu_cp();
+    amrex::MultiFab* Getsigma_fp();
+    amrex::MultiFab* Getsigma_cp();
 
     const MultiSigmaBox& GetMultiSigmaBox_fp () const
         { return *sigba_fp; }
@@ -200,6 +209,14 @@ private:
     std::array<std::unique_ptr<amrex::MultiFab>,3> pml_H_fp;
     std::array<std::unique_ptr<amrex::MultiFab>,3> pml_H_cp;
 #endif
+
+    // macroproperties in PML, eps-permittivity, mu-permeability, sigma-condictivity
+    std::unique_ptr<amrex::MultiFab> pml_eps_fp;
+    std::unique_ptr<amrex::MultiFab> pml_mu_fp;
+    std::unique_ptr<amrex::MultiFab> pml_sigma_fp;
+    std::unique_ptr<amrex::MultiFab> pml_eps_cp;
+    std::unique_ptr<amrex::MultiFab> pml_mu_cp;
+    std::unique_ptr<amrex::MultiFab> pml_sigma_cp;
 
     std::unique_ptr<MultiSigmaBox> sigba_fp;
     std::unique_ptr<MultiSigmaBox> sigba_cp;

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -516,17 +516,17 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     pml_H_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
         WarpX::GetInstance().getHfield_fp(0,2).ixType().toIntVect() ), dm, 2, ngb );
 #endif
-    
+
     if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
         // Allocating macroproperties in pml at cell-centers
         pml_eps_fp = std::make_unique<MultiFab>(ba, dm, 1, nge);
         pml_mu_fp = std::make_unique<MultiFab>(ba, dm, 1, nge);
         pml_sigma_fp = std::make_unique<MultiFab>(ba, dm, 1, nge);
-       
+
         // Initializing macroparameter multifab //
         auto& warpx = WarpX::GetInstance();
         auto& macroscopic_properties = warpx.m_macroscopic_properties;
-        
+
         // Initialize sigma, conductivity
         if (macroscopic_properties->m_sigma_s == "constant") {
             pml_sigma_fp->setVal(macroscopic_properties->m_sigma);
@@ -650,7 +650,7 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
             // Initializing macroparameter multifab //
             auto& warpx = WarpX::GetInstance();
             auto& macroscopic_properties = warpx.m_macroscopic_properties;
-            
+
             // Initialize sigma, conductivity
             if (macroscopic_properties->m_sigma_s == "constant") {
                 pml_sigma_cp->setVal(macroscopic_properties->m_sigma);

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -546,7 +546,7 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
         // Initialize mu, permeability
         if (macroscopic_properties->m_mu_s == "constant") {
             pml_mu_fp->setVal(macroscopic_properties->m_mu);
-        } else if (macroscopic_properties->m_sigma_s == "parse_mu_function") {
+        } else if (macroscopic_properties->m_mu_s == "parse_mu_function") {
             macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_mu_fp.get(),
                 getParser(macroscopic_properties->m_mu_parser), lev);
         }

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -11,7 +11,6 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "WarpX.H"
-//#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 
 #include <AMReX_Print.H>
 #include <AMReX_VisMF.H>

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -11,6 +11,7 @@
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "WarpX.H"
+//#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
 
 #include <AMReX_Print.H>
 #include <AMReX_VisMF.H>
@@ -432,7 +433,8 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
 #endif
           int do_dive_cleaning, int do_moving_window,
           int /*pml_has_particles*/, int do_pml_in_domain,
-          const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi)
+          const amrex::IntVect do_pml_Lo, const amrex::IntVect do_pml_Hi,
+          const int lev)
     : m_geom(geom),
       m_cgeom(cgeom)
 {
@@ -514,6 +516,42 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
     pml_H_fp[2] = std::make_unique<MultiFab>(amrex::convert( ba,
         WarpX::GetInstance().getHfield_fp(0,2).ixType().toIntVect() ), dm, 2, ngb );
 #endif
+    
+    if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
+        // Allocating macroproperties in pml at cell-centers
+        pml_eps_fp = std::make_unique<MultiFab>(ba, dm, 1, nge);
+        pml_mu_fp = std::make_unique<MultiFab>(ba, dm, 1, nge);
+        pml_sigma_fp = std::make_unique<MultiFab>(ba, dm, 1, nge);
+       
+        // Initializing macroparameter multifab //
+        auto& warpx = WarpX::GetInstance();
+        auto& macroscopic_properties = warpx.m_macroscopic_properties;
+        
+        // Initialize sigma, conductivity
+        if (macroscopic_properties->m_sigma_s == "constant") {
+            pml_sigma_fp->setVal(macroscopic_properties->m_sigma);
+        } else if (macroscopic_properties->m_sigma_s == "parse_sigma_function") {
+            macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_sigma_fp.get(),
+                getParser(macroscopic_properties->m_sigma_parser), lev);
+        }
+
+        // Initialize epsilon, permittivity
+        if (macroscopic_properties->m_epsilon_s == "constant") {
+            pml_eps_fp->setVal(macroscopic_properties->m_epsilon);
+        } else if (macroscopic_properties->m_epsilon_s == "parse_epsilon_function") {
+            macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_eps_fp.get(),
+                getParser(macroscopic_properties->m_epsilon_parser), lev);
+        }
+
+        // Initialize mu, permeability
+        if (macroscopic_properties->m_mu_s == "constant") {
+            pml_mu_fp->setVal(macroscopic_properties->m_mu);
+        } else if (macroscopic_properties->m_sigma_s == "parse_mu_function") {
+            macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_mu_fp.get(),
+                getParser(macroscopic_properties->m_mu_parser), lev);
+        }
+
+    }
 
     pml_E_fp[0]->setVal(0.0);
     pml_E_fp[1]->setVal(0.0);
@@ -601,6 +639,44 @@ PML::PML (const BoxArray& grid_ba, const DistributionMapping& /*grid_dm*/,
         pml_H_cp[2] = std::make_unique<MultiFab>(amrex::convert( cba,
             WarpX::GetInstance().getHfield_cp(1,2).ixType().toIntVect() ), cdm, 2, ngb );
 #endif
+
+
+        // Allocating macroproperties in pml at cell-centers
+        if (WarpX::em_solver_medium == MediumForEM::Macroscopic) {
+            pml_eps_cp = std::make_unique<MultiFab>(cba, dm, 1, nge);
+            pml_mu_cp = std::make_unique<MultiFab>(cba, dm, 1, nge);
+            pml_sigma_cp = std::make_unique<MultiFab>(cba, dm, 1, nge);
+
+            // Initializing macroparameter multifab //
+            auto& warpx = WarpX::GetInstance();
+            auto& macroscopic_properties = warpx.m_macroscopic_properties;
+            
+            // Initialize sigma, conductivity
+            if (macroscopic_properties->m_sigma_s == "constant") {
+                pml_sigma_cp->setVal(macroscopic_properties->m_sigma);
+            } else if (macroscopic_properties->m_sigma_s == "parse_sigma_function") {
+                macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_sigma_cp.get(),
+                    getParser(macroscopic_properties->m_sigma_parser), lev);
+            }
+
+            // Initialize epsilon, permittivity
+            if (macroscopic_properties->m_epsilon_s == "constant") {
+                pml_eps_cp->setVal(macroscopic_properties->m_epsilon);
+            } else if (macroscopic_properties->m_epsilon_s == "parse_epsilon_function") {
+                macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_eps_cp.get(),
+                    getParser(macroscopic_properties->m_epsilon_parser), lev);
+            }
+
+            // Initialize mu, permeability
+            if (macroscopic_properties->m_mu_s == "constant") {
+                pml_mu_cp->setVal(macroscopic_properties->m_mu);
+            } else if (macroscopic_properties->m_sigma_s == "parse_mu_function") {
+                macroscopic_properties->InitializeMacroMultiFabUsingParser(pml_mu_cp.get(),
+                    getParser(macroscopic_properties->m_mu_parser), lev);
+            }
+
+
+        }
 
         pml_E_cp[0]->setVal(0.0);
         pml_E_cp[1]->setVal(0.0);
@@ -803,6 +879,43 @@ MultiFab*
 PML::GetF_cp ()
 {
     return pml_F_cp.get();
+}
+
+// Return macroscopic pml multifabs
+amrex::MultiFab*
+PML::Geteps_fp()
+{
+    return pml_eps_fp.get();
+}
+
+amrex::MultiFab*
+PML::Getmu_fp()
+{
+    return pml_mu_fp.get();
+}
+
+amrex::MultiFab*
+PML::Getsigma_fp()
+{
+    return pml_sigma_fp.get();
+}
+
+amrex::MultiFab*
+PML::Geteps_cp()
+{
+    return pml_eps_cp.get();
+}
+
+amrex::MultiFab*
+PML::Getmu_cp()
+{
+    return pml_mu_cp.get();
+}
+
+amrex::MultiFab*
+PML::Getsigma_cp()
+{
+    return pml_sigma_cp.get();
 }
 
 void

--- a/Source/FieldSolver/FiniteDifferenceSolver/CMakeLists.txt
+++ b/Source/FieldSolver/FiniteDifferenceSolver/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(WarpX
     EvolveFPML.cpp
     FiniteDifferenceSolver.cpp
     MacroscopicEvolveE.cpp
+    MacroscopicEvolveEPML.cpp
 )
 
 if(WarpX_MAG_LLG)

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -128,11 +128,29 @@ class FiniteDifferenceSolver
                      std::array< amrex::MultiFab*, 3 > const Efield,
                      amrex::Real const dt );
 
+       void MacroscopicEvolveEPML ( std::array< amrex::MultiFab*, 3 > Efield,
+#ifndef WARPX_MAG_LLG
+                      std::array< amrex::MultiFab*, 3 > const Bfield,
+#else
+                      std::array< amrex::MultiFab*, 3 > const Hfield,
+#endif
+                      std::array< amrex::MultiFab*, 3 > const Jfield,
+                      amrex::MultiFab* const Ffield,
+                      MultiSigmaBox const& sigba,
+                      amrex::Real const dt, bool pml_has_particles,
+                      std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+                      amrex::MultiFab* const eps_mf,
+                      amrex::MultiFab* const mu_mf,
+                      amrex::MultiFab* const sigma_mf);
+
+
 #ifdef WARPX_MAG_LLG
         void EvolveHPML ( std::array< amrex::MultiFab*, 3 > Hfield,
                       std::array< amrex::MultiFab*, 3 > const Efield,
                       amrex::Real const dt );
 #endif
+
+ 
 
     private:
 
@@ -263,6 +281,24 @@ class FiniteDifferenceSolver
         void EvolveFPMLCartesian ( amrex::MultiFab* Ffield,
                       std::array< amrex::MultiFab*, 3 > const Efield,
                       amrex::Real const dt );
+
+        template< typename T_Algo, typename T_MacroAlgo >
+        void MacroscopicEvolveEPMLCartesian (
+            std::array< amrex::MultiFab*, 3 > Efield,
+#ifndef WARPX_MAG_LLG
+            std::array< amrex::MultiFab*, 3 > const Bfield,
+#else
+            std::array< amrex::MultiFab*, 3 > const Hfield,
+#endif
+            std::array< amrex::MultiFab*, 3 > const Jfield,
+            amrex::MultiFab* const Ffield,
+            MultiSigmaBox const& sigba,
+            amrex::Real const dt, bool pml_has_particles,
+            std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+            amrex::MultiFab* const eps_mf,
+            amrex::MultiFab* const mu_mf,
+            amrex::MultiFab* const sigma_mf );
+
 
 #ifdef WARPX_MAG_LLG
         template< typename T_Algo >

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -150,8 +150,6 @@ class FiniteDifferenceSolver
                       amrex::Real const dt );
 #endif
 
-
-
     private:
 
         int m_fdtd_algo;

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -150,7 +150,7 @@ class FiniteDifferenceSolver
                       amrex::Real const dt );
 #endif
 
- 
+
 
     private:
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -157,7 +157,7 @@ void FiniteDifferenceSolver::MacroscopicEvolveEPMLCartesian (
         Array4<Real> const& sigma_arr = sigma_mf->array(mfi);
         Array4<Real> const& eps_arr = eps_mf->array(mfi);
         Array4<Real> const& mu_arr = mu_mf->array(mfi);
-      
+
 
         // Extract stencil coefficients
         Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -122,12 +122,6 @@ void FiniteDifferenceSolver::MacroscopicEvolveEPMLCartesian (
     amrex::MultiFab* const mu_mf,
     amrex::MultiFab* const sigma_mf ) {
 
-    Real c2 = PhysConst::c * PhysConst::c;
-
-#ifdef WARPX_MAG_LLG
-    c2 *= PhysConst::mu0;
-#endif
-
     // Index type required for calling CoarsenIO::Interp to interpolate macroscopic
     // properties from their respective staggering to the Ex, Ey, Ez locations
     amrex::GpuArray<int, 3> const& sigma_stag = macroscopic_properties->sigma_IndexType;

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -1,0 +1,302 @@
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
+#ifdef WARPX_DIM_RZ
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CylindricalYeeAlgorithm.H"
+#else
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H"
+#endif
+#include "BoundaryConditions/PML.H"
+#include "BoundaryConditions/PML_current.H"
+#include "BoundaryConditions/PMLComponent.H"
+#include "Utils/CoarsenIO.H"
+#include "Utils/WarpXConst.H"
+#include <AMReX_Gpu.H>
+#include <AMReX.H>
+
+using namespace amrex;
+
+/**
+ * \brief Update the E field, over one timestep
+ */
+void FiniteDifferenceSolver::MacroscopicEvolveEPML (
+    std::array< amrex::MultiFab*, 3 > Efield,
+#ifndef WARPX_MAG_LLG
+    std::array< amrex::MultiFab*, 3 > const Bfield,
+#else
+    std::array< amrex::MultiFab*, 3 > const Hfield,
+#endif
+    std::array< amrex::MultiFab*, 3 > const Jfield,
+    amrex::MultiFab* const Ffield,
+    MultiSigmaBox const& sigba,
+    amrex::Real const dt, bool pml_has_particles,
+    std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+    amrex::MultiFab* const eps_mf,
+    amrex::MultiFab* const mu_mf,
+    amrex::MultiFab* const sigma_mf) {
+
+   // Select algorithm (The choice of algorithm is a runtime option,
+   // but we compile code for each algorithm, using templates)
+#ifdef WARPX_DIM_RZ
+    amrex::ignore_unused(Efield, Bfield, Jfield, Ffield, sigba, dt, pml_has_particles);
+    amrex::Abort("PML are not implemented in cylindrical geometry.");
+#else
+    if (m_do_nodal) {
+
+        amrex::Abort("Macro E-push is not implemented for nodal, yet.");
+
+    } else if (m_fdtd_algo == MaxwellSolverAlgo::Yee) {
+
+        if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::LaxWendroff) {
+            MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, LaxWendroffAlgo> (
+                Efield,
+#ifndef WARPX_MAG_LLG
+                Bfield,
+#else
+                Hfield,
+#endif
+                Jfield, Ffield, sigba, dt, pml_has_particles,
+                macroscopic_properties, eps_mf, mu_mf, sigma_mf );
+        }
+        else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::BackwardEuler) {
+            MacroscopicEvolveEPMLCartesian <CartesianYeeAlgorithm, BackwardEulerAlgo> (
+                Efield,
+#ifndef WARPX_MAG_LLG
+                Bfield,
+#else
+                Hfield,
+#endif
+                Jfield, Ffield, sigba, dt, pml_has_particles,
+                macroscopic_properties, eps_mf, mu_mf, sigma_mf );
+        }
+
+    } else if (m_fdtd_algo == MaxwellSolverAlgo::CKC) {
+        // Note :: Macroscopic Evolve E for PML is the same for CKC and Yee
+        if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::LaxWendroff) {
+            MacroscopicEvolveEPMLCartesian <CartesianCKCAlgorithm, LaxWendroffAlgo> (
+                Efield,
+#ifndef WARPX_MAG_LLG
+                Bfield,
+#else
+                Hfield,
+#endif
+                Jfield, Ffield, sigba, dt, pml_has_particles,
+                macroscopic_properties, eps_mf, mu_mf, sigma_mf );
+        }
+        else if (WarpX::macroscopic_solver_algo == MacroscopicSolverAlgo::BackwardEuler) {
+            MacroscopicEvolveEPMLCartesian <CartesianCKCAlgorithm, BackwardEulerAlgo> (
+                Efield,
+#ifndef WARPX_MAG_LLG
+                Bfield,
+#else
+                Hfield,
+#endif
+                Jfield, Ffield, sigba, dt, pml_has_particles,
+                macroscopic_properties, eps_mf, mu_mf, sigma_mf );
+        }
+
+    } else {
+        amrex::Abort("Unknown algorithm");
+    }
+#endif
+}
+
+
+#ifndef WARPX_DIM_RZ
+
+template<typename T_Algo, typename T_MacroAlgo>
+void FiniteDifferenceSolver::MacroscopicEvolveEPMLCartesian (
+    std::array< amrex::MultiFab*, 3 > Efield,
+#ifndef WARPX_MAG_LLG
+    std::array< amrex::MultiFab*, 3 > const Bfield,
+#else
+    std::array< amrex::MultiFab*, 3 > const Hfield,
+#endif
+    std::array< amrex::MultiFab*, 3 > const Jfield,
+    amrex::MultiFab* const Ffield,
+    MultiSigmaBox const& sigba,
+    amrex::Real const dt, bool pml_has_particles,
+    std::unique_ptr<MacroscopicProperties> const& macroscopic_properties,
+    amrex::MultiFab* const eps_mf,
+    amrex::MultiFab* const mu_mf,
+    amrex::MultiFab* const sigma_mf ) {
+
+    Real c2 = PhysConst::c * PhysConst::c;
+
+#ifdef WARPX_MAG_LLG
+    c2 *= PhysConst::mu0;
+#endif
+
+    // Index type required for calling CoarsenIO::Interp to interpolate macroscopic
+    // properties from their respective staggering to the Ex, Ey, Ez locations
+    amrex::GpuArray<int, 3> const& sigma_stag = macroscopic_properties->sigma_IndexType;
+    amrex::GpuArray<int, 3> const& epsilon_stag = macroscopic_properties->epsilon_IndexType;
+    amrex::GpuArray<int, 3> const& Ex_stag = macroscopic_properties->Ex_IndexType;
+    amrex::GpuArray<int, 3> const& Ey_stag = macroscopic_properties->Ey_IndexType;
+    amrex::GpuArray<int, 3> const& Ez_stag = macroscopic_properties->Ez_IndexType;
+    amrex::GpuArray<int, 3> const& macro_cr     = macroscopic_properties->macro_cr_ratio;
+
+    // Loop through the grids, and over the tiles within each grid
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+        // Extract field data for this grid/tile
+        Array4<Real> const& Ex = Efield[0]->array(mfi);
+        Array4<Real> const& Ey = Efield[1]->array(mfi);
+        Array4<Real> const& Ez = Efield[2]->array(mfi);
+#ifndef WARPX_MAG_LLG
+        Array4<Real> const& Bx = Bfield[0]->array(mfi);
+        Array4<Real> const& By = Bfield[1]->array(mfi);
+        Array4<Real> const& Bz = Bfield[2]->array(mfi);
+#endif
+
+        // material macroscopic properties
+        Array4<Real> const& sigma_arr = sigma_mf->array(mfi);
+        Array4<Real> const& eps_arr = eps_mf->array(mfi);
+        Array4<Real> const& mu_arr = mu_mf->array(mfi);
+      
+
+        // Extract stencil coefficients
+        Real const * const AMREX_RESTRICT coefs_x = m_stencil_coefs_x.dataPtr();
+        int const n_coefs_x = m_stencil_coefs_x.size();
+        Real const * const AMREX_RESTRICT coefs_y = m_stencil_coefs_y.dataPtr();
+        int const n_coefs_y = m_stencil_coefs_y.size();
+        Real const * const AMREX_RESTRICT coefs_z = m_stencil_coefs_z.dataPtr();
+        int const n_coefs_z = m_stencil_coefs_z.size();
+
+#ifndef WARPX_MAG_LLG
+        FieldAccessorMacroscopic const Hx(Bx, mu_arr);
+        FieldAccessorMacroscopic const Hy(By, mu_arr);
+        FieldAccessorMacroscopic const Hz(Bz, mu_arr);
+#else
+        Array4<Real> const Hx = Hfield[0]->array(mfi);
+        Array4<Real> const Hy = Hfield[1]->array(mfi);
+        Array4<Real> const Hz = Hfield[2]->array(mfi);
+#endif
+
+        // Extract tileboxes for which to loop
+        Box const& tex  = mfi.tilebox(Efield[0]->ixType().toIntVect());
+        Box const& tey  = mfi.tilebox(Efield[1]->ixType().toIntVect());
+        Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
+        // starting component to interpolate macro properties to Ex, Ey, Ez locations
+        const int scomp = 0;
+
+        // Loop over the cells and update the fields
+        amrex::ParallelFor(tex, tey, tez,
+
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                // Interpolate conductivity, sigma, to Ex position on the grid
+                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                           Ex_stag, macro_cr, i, j, k, scomp);
+                // Interpolated permittivity, epsilon, to Ex position on the grid
+                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                           Ex_stag, macro_cr, i, j, k, scomp);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                Ex(i, j, k, PMLComp::xz) = alpha * Ex(i, j, k, PMLComp::xz) - beta * (
+                    T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k, PMLComp::yx)
+                  + T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k, PMLComp::yz) );
+                Ex(i, j, k, PMLComp::xy) = alpha * Ex(i, j, k, PMLComp::xy) + beta * (
+                    T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k, PMLComp::zx)
+                  + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k, PMLComp::zy) );
+            },
+
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                           Ey_stag, macro_cr, i, j, k, scomp);
+                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                           Ey_stag, macro_cr, i, j, k, scomp);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                Ey(i, j, k, PMLComp::yx) = alpha * Ey(i, j, k, PMLComp::yx) - beta * (
+                    T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k, PMLComp::zx)
+                  + T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k, PMLComp::zy) );
+                Ey(i, j, k, PMLComp::yz) = alpha * Ey(i, j, k, PMLComp::yz) + beta * (
+                    T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k, PMLComp::xy)
+                  + T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k, PMLComp::xz) );
+            },
+
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                           Ez_stag, macro_cr, i, j, k, scomp);
+                amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                           Ez_stag, macro_cr, i, j, k, scomp);
+                amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+                amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                Ez(i, j, k, PMLComp::zy) = alpha * Ez(i, j, k, PMLComp::zy) - beta * (
+                    T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k, PMLComp::xy)
+                  + T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k, PMLComp::xz) );
+                Ez(i, j, k, PMLComp::zx) = alpha * Ez(i, j, k, PMLComp::zx) + beta * (
+                    T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k, PMLComp::yx)
+                  + T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k, PMLComp::yz) );
+            }
+
+        );
+
+        // Update the E field in the PML, using the current
+        // deposited by the particles in the PML
+        if (pml_has_particles) {
+
+            // Extract field data for this grid/tile
+            Array4<Real> const& Jx = Jfield[0]->array(mfi);
+            Array4<Real> const& Jy = Jfield[1]->array(mfi);
+            Array4<Real> const& Jz = Jfield[2]->array(mfi);
+            const Real* sigmaj_x = sigba[mfi].sigma[0].data();
+            const Real* sigmaj_y = sigba[mfi].sigma[1].data();
+            const Real* sigmaj_z = sigba[mfi].sigma[2].data();
+            int const x_lo = sigba[mfi].sigma[0].lo();
+#if (AMREX_SPACEDIM == 3)
+            int const y_lo = sigba[mfi].sigma[1].lo();
+            int const z_lo = sigba[mfi].sigma[2].lo();
+#else
+            int const y_lo = 0;
+            int const z_lo = sigba[mfi].sigma[1].lo();
+#endif
+
+            amrex::ParallelFor( tex, tey, tez,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    // Interpolate conductivity, sigma, to Ex position on the grid
+                    amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                               Ex_stag, macro_cr, i, j, k, scomp);
+                    // Interpolated permittivity, epsilon, to Ex position on the grid
+                    amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                               Ex_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                    push_ex_pml_current(i, j, k, Ex, Jx,
+                        sigmaj_y, sigmaj_z, y_lo, z_lo, beta);
+                },
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                               Ey_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                               Ey_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                    push_ey_pml_current(i, j, k, Ey, Jy,
+                        sigmaj_x, sigmaj_z, x_lo, z_lo, beta);
+                },
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    amrex::Real const sigma_interp = CoarsenIO::Interp( sigma_arr, sigma_stag,
+                                               Ez_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real const epsilon_interp = CoarsenIO::Interp( eps_arr, epsilon_stag,
+                                               Ez_stag, macro_cr, i, j, k, scomp);
+                    amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+
+                    push_ez_pml_current(i, j, k, Ez, Jz,
+                        sigmaj_x, sigmaj_y, x_lo, y_lo, beta);
+                }
+            );
+        }
+
+    }
+
+}
+
+#endif // corresponds to ifndef WARPX_DIM_RZ

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveEPML.cpp
@@ -5,7 +5,7 @@
 #else
 #   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
 #   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H"
-#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H"
+#   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/FieldAccessorFunctors.H"
 #endif
 #include "BoundaryConditions/PML.H"
 #include "BoundaryConditions/PML_current.H"

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H
@@ -184,13 +184,30 @@ public:
      };
 #endif //closes ifdef MAG_LLG
 
-private:
      /** Conductivity, sigma, of the medium */
      amrex::Real m_sigma = 0.0;
      /** Permittivity, epsilon, of the medium */
      amrex::Real m_epsilon = PhysConst::ep0;
      /** Permeability, mu, of the medium */
      amrex::Real m_mu = PhysConst::mu0;
+
+     /** Stores initialization type for conductivity : constant or parser */
+     std::string m_sigma_s = "constant";
+     /** Stores initialization type for permittivity : constant or parser */
+     std::string m_epsilon_s = "constant";
+     /** Stores initialization type for permeability : constant or parser */
+     std::string m_mu_s = "constant";
+
+     /** Parser Wrappers */
+     // The ParserWrapper struct is constructed to safely use the GpuParser class
+     // that can essentially be though of as a raw pointer. The GpuParser does
+     // not have an explicit destructor and the AddPlasma subroutines handle the GpuParser
+     // in a safe way. The ParserWrapper struct is used to avoid memory leak
+     // in the EB parser functions.
+     std::unique_ptr<ParserWrapper<3> > m_sigma_parser;
+     std::unique_ptr<ParserWrapper<3> > m_epsilon_parser;
+     std::unique_ptr<ParserWrapper<3> > m_mu_parser;
+private:
 
 #ifdef WARPX_MAG_LLG // preferred to use this tag multiple times for different variable types to keep formatting consistent
      /** Saturation magnetization, only applies for magnetic materials */
@@ -228,12 +245,6 @@ private:
      std::unique_ptr<amrex::MultiFab> m_mag_gamma_mf;
 #endif
 
-     /** Stores initialization type for conductivity : constant or parser */
-     std::string m_sigma_s = "constant";
-     /** Stores initialization type for permittivity : constant or parser */
-     std::string m_epsilon_s = "constant";
-     /** Stores initialization type for permeability : constant or parser */
-     std::string m_mu_s = "constant";
 
 #ifdef WARPX_MAG_LLG
      std::string m_mag_Ms_s;
@@ -257,9 +268,6 @@ private:
      // not have an explicit destructor and the AddPlasma subroutines handle the GpuParser
      // in a safe way. The ParserWrapper struct is used to avoid memory leak
      // in the EB parser functions.
-     std::unique_ptr<ParserWrapper<3> > m_sigma_parser;
-     std::unique_ptr<ParserWrapper<3> > m_epsilon_parser;
-     std::unique_ptr<ParserWrapper<3> > m_mu_parser;
 #ifdef WARPX_MAG_LLG
      std::unique_ptr<ParserWrapper<3> > m_mag_Ms_parser;
      std::unique_ptr<ParserWrapper<3> > m_mag_alpha_parser;

--- a/Source/FieldSolver/FiniteDifferenceSolver/Make.package
+++ b/Source/FieldSolver/FiniteDifferenceSolver/Make.package
@@ -14,6 +14,7 @@ CEXE_sources += EvolveHPML.cpp
 CEXE_sources += EvolveBPML.cpp
 CEXE_sources += EvolveEPML.cpp
 CEXE_sources += EvolveFPML.cpp
+CEXE_sources += MacroscopicEvolveEPML.cpp
 
 include $(WARPX_HOME)/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/Make.package
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -346,27 +346,35 @@ WarpX::MacroscopicEvolveE (int lev, PatchType patch_type, amrex::Real a_dt) {
     // Evolve E field in PML cells
     if (do_pml && pml[lev]->ok()) {
         if (patch_type == PatchType::fine) {
-            m_fdtd_solver_fp[lev]->EvolveEPML(
+            m_fdtd_solver_fp[lev]->MacroscopicEvolveEPML(
                 pml[lev]->GetE_fp(),
-#ifdef WARPX_MAG_LLG
-                pml[lev]->GetH_fp(),
-#else
+#ifndef WARPX_MAG_LLG
                 pml[lev]->GetB_fp(),
+#else
+                pml[lev]->GetH_fp(),
 #endif
                 pml[lev]->Getj_fp(), pml[lev]->GetF_fp(),
                 pml[lev]->GetMultiSigmaBox_fp(),
-                a_dt, pml_has_particles );
+                a_dt, pml_has_particles,
+                m_macroscopic_properties,
+                pml[lev]->Geteps_fp(),
+                pml[lev]->Getmu_fp(),
+                pml[lev]->Getsigma_fp() );
         } else {
-            m_fdtd_solver_cp[lev]->EvolveEPML(
+            m_fdtd_solver_cp[lev]->MacroscopicEvolveEPML(
                 pml[lev]->GetE_cp(),
-#ifdef WARPX_MAG_LLG
-                pml[lev]->GetH_cp(),
-#else
+#ifndef WARPX_MAG_LLG
                 pml[lev]->GetB_cp(),
+#else
+                pml[lev]->GetH_cp(),
 #endif
                 pml[lev]->Getj_cp(), pml[lev]->GetF_cp(),
                 pml[lev]->GetMultiSigmaBox_cp(),
-                a_dt, pml_has_particles );
+                a_dt, pml_has_particles,
+                m_macroscopic_properties,
+                pml[lev]->Geteps_cp(),
+                pml[lev]->Getmu_cp(),
+                pml[lev]->Getsigma_cp() );
         }
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -176,7 +176,7 @@ WarpX::InitPML ()
 #endif
                              do_dive_cleaning, do_moving_window,
                              pml_has_particles, do_pml_in_domain,
-                             do_pml_Lo_corrected, do_pml_Hi);
+                             do_pml_Lo_corrected, do_pml_Hi,0);
         for (int lev = 1; lev <= finest_level; ++lev)
         {
             amrex::IntVect do_pml_Lo_MR = amrex::IntVect::TheUnitVector();
@@ -194,7 +194,7 @@ WarpX::InitPML ()
 #endif
                                    do_dive_cleaning, do_moving_window,
                                    pml_has_particles, do_pml_in_domain,
-                                   do_pml_Lo_MR, amrex::IntVect::TheUnitVector());
+                                   do_pml_Lo_MR, amrex::IntVect::TheUnitVector(), lev);
         }
     }
 }


### PR DESCRIPTION
In this PR, the PML implementation is extended to account for macroscopic properties.

The input file  used to test this is attached below
[inputs_laser_mod.3d.txt](https://github.com/RevathiJambunathan/WarpX/files/5656945/inputs_laser_mod.3d.txt)


The test-case includes eps_r=4 for the material, and a laser in injected at an angle.
The current evolveM_dev code reflects the wave at the domain-boundary.

With this PR, now the waves are absorbed at the boundary.

![with_macro_pml](https://user-images.githubusercontent.com/41089244/101441644-73abf600-38ce-11eb-86aa-627d65402e88.gif)








