### PR TITLE
fixing typo for call to damp B PML for H

### DIFF
--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -162,7 +162,7 @@ WarpX::DampPML (int lev, PatchType patch_type)
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 warpx_damp_pml_by(i, j, k, pml_Hyfab, Hy_stag, sigma_fac_x, sigma_fac_z,
-                                  sigma_star_fac_z, sigma_star_fac_x, z_lo, x_lo);
+                                  sigma_star_fac_x, sigma_star_fac_z, x_lo, z_lo);
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 warpx_damp_pml_bz(i, j, k, pml_Hzfab, Hz_stag, sigma_fac_x, sigma_fac_y,


### PR DESCRIPTION
Fixing a typo added in commit 
https://github.com/RevathiJambunathan/WarpX/commit/83b93f696b5a16a8c6329fb54dc33930a483130c

to ensure that the call to damp_pml_By for Hy is called correctly.