### PR TITLE
convergence test for paper

### DIFF
--- a/Examples/Tests/Macroscopic_Maxwell/inputs_3d_LLG_evolveM_convergence
+++ b/Examples/Tests/Macroscopic_Maxwell/inputs_3d_LLG_evolveM_convergence
@@ -6,30 +6,43 @@
 ####### GENERAL PARAMETERS ######
 #################################
 
-max_step = 10
+# space-time convergence
+
+max_step = 5
+plt.period = 5
 amr.n_cell = 32 32 32
 amr.max_grid_size = 16
+
+#max_step = 10
+#plt.period = 10
+#amr.n_cell = 64 64 64
+#amr.max_grid_size = 32
+
+#max_step = 20
+#plt.period = 20
+#amr.n_cell = 128 128 128
+#amr.max_grid_size = 64
+
+warpx.cfl = 0.9
 
 amr.blocking_factor = 16
 geometry.coord_sys = 0
 geometry.is_periodic = 1 1 1
 
-geometry.prob_lo = -1.2e-1 -1.2e-1 -1.2e-1
-geometry.prob_hi =  1.2e-1  1.2e-1  1.2e-1
+geometry.prob_lo = -0.1 -0.1 -0.1
+geometry.prob_hi =  0.1  0.1  0.1
 
 amr.max_level = 0
 
 my_constants.pi = 3.14159265359
-my_constants.L = 2.4e-1
 my_constants.c = 299792458.
-my_constants.wavelength = 1.2e-1
+my_constants.wavelength = 0.1
 
 #################################
 ############ NUMERICS ###########
 #################################
 warpx.verbose = 0
 warpx.use_filter = 0
-warpx.cfl = 0.5
 warpx.do_pml = 0
 warpx.mag_time_scheme_order = 2 # default 1
 warpx.mag_M_normalization = 1 # 1 is saturated
@@ -41,23 +54,24 @@ algo.em_solver_medium = macroscopic # vacuum/macroscopic
 algo.macroscopic_sigma_method = laxwendroff # laxwendroff or backwardeuler
 
 macroscopic.sigma_init_style = "parse_sigma_function" # parse or "constant"
-macroscopic.sigma_function(x,y,z) = "0.0"
+macroscopic.sigma_function(x,y,z) = "0."
+macroscopic.sigma_function(x,y,z) = "0.1*exp(-1000.*(x*x+y*y+z*z))"
 
 macroscopic.epsilon_init_style = "parse_epsilon_function" # parse or "constant"
-macroscopic.epsilon_function(x,y,z) = "8.8541878128e-12"
+macroscopic.epsilon_function(x,y,z) = "9.8541878128e-12*(1 + exp(-1000.*(x*x+y*y+z*z)))"
 
 macroscopic.mu_init_style = "parse_mu_function" # parse or "constant"
 macroscopic.mu_function(x,y,z) = "1.25663706212e-06"
 
 #unit conversion: 1 Gauss = (1000/4pi) A/m
 macroscopic.mag_Ms_init_style = "parse_mag_Ms_function" # parse or "constant"
-macroscopic.mag_Ms_function(x,y,z) = "1.4e5" # in unit A/m, equal to 1750 Gauss
+macroscopic.mag_Ms_function(x,y,z) = "1.e4*(1 + exp(-1000.*(x*x+y*y+z*z)))"
 
 macroscopic.mag_alpha_init_style = "parse_mag_alpha_function" # parse or "constant"
-macroscopic.mag_alpha_function(x,y,z) = "5e-01" # alpha is unitless, typical values range from 1e-3 ~ 1e-5
+macroscopic.mag_alpha_function(x,y,z) = "0.5*(1 + exp(-1000.*(x*x+y*y+z*z)))" # alpha is unitless, typical values range from 1e-3 ~ 1e-5
 
 macroscopic.mag_gamma_init_style = "parse_mag_gamma_function" # parse or "constant"
-macroscopic.mag_gamma_function(x,y,z) = "-1.759e11" # gyromagnetic ratio is constant for electrons in all materials
+macroscopic.mag_gamma_function(x,y,z) = "-1.759e11*(1 + exp(-1000.*(x*x+y*y+z*z)))"
 
 macroscopic.mag_max_iter = 100 # maximum number of M iteration in each time step
 macroscopic.mag_tol = 1.e-6 # M magnitude relative error tolerance compared to previous iteration
@@ -68,31 +82,27 @@ macroscopic.mag_normalized_error = 0.1 # if M magnitude relatively changes more 
 #################################
 
 warpx.E_ext_grid_init_style = parse_E_ext_grid_function
-warpx.Ex_external_grid_function(x,y,z) = "1000*exp(-z**2/L**2)*cos(2*pi*z/wavelength)"
-warpx.Ey_external_grid_function(x,y,z) = 0.
-warpx.Ez_external_grid_function(x,y,z) = 0.
+warpx.Ex_external_grid_function(x,y,z) = "1e6*cos(2*pi*z/wavelength)"
+warpx.Ey_external_grid_function(x,y,z) = "1e6*cos(2*pi*x/wavelength)"
+warpx.Ez_external_grid_function(x,y,z) = "1e6*cos(2*pi*y/wavelength)"
 
 warpx.H_ext_grid_init_style = parse_H_ext_grid_function
-warpx.Hx_external_grid_function(x,y,z)= 0.
-warpx.Hy_external_grid_function(x,y,z) = "1000*exp(-z**2/L**2)*cos(2*pi*z/wavelength)/(120*pi)"
-warpx.Hz_external_grid_function(x,y,z) = 0.
-
-#unit conversion: 1 Gauss = 1 Oersted = (1000/4pi) A/m
-#calculation of H_bias: H_bias (oe) = frequency / 2.8e6
+warpx.Hx_external_grid_function(x,y,z) = "1e6*cos(2*pi*y/wavelength)/(120*pi)"
+warpx.Hy_external_grid_function(x,y,z) = "1e6*cos(2*pi*z/wavelength)/(120*pi)"
+warpx.Hz_external_grid_function(x,y,z) = "1e6*cos(2*pi*x/wavelength)/(120*pi)"
 
 warpx.H_bias_ext_grid_init_style = parse_H_bias_ext_grid_function
-warpx.Hx_bias_external_grid_function(x,y,z)= 0.
-warpx.Hy_bias_external_grid_function(x,y,z)= 0.
-warpx.Hz_bias_external_grid_function(x,y,z)= 3e4 # in A/m, equal to 382 Oersted
+warpx.Hx_bias_external_grid_function(x,y,z) = 0.
+warpx.Hy_bias_external_grid_function(x,y,z) = 0.
+warpx.Hz_bias_external_grid_function(x,y,z) = 0.
 
 warpx.M_ext_grid_init_style = parse_M_ext_grid_function
-warpx.Mx_external_grid_function(x,y,z)= "1.4e5"
-warpx.My_external_grid_function(x,y,z)= 0.
+warpx.Mx_external_grid_function(x,y,z) = "1.e4*(1 + exp(-1000.*(x*x+y*y+z*z)))"
+warpx.My_external_grid_function(x,y,z) = 0.
 warpx.Mz_external_grid_function(x,y,z) = 0.
 
-#Diagnostics
+# Diagnostics
 diagnostics.diags_names = plt
-plt.period = 40
 plt.diag_type = Full
 plt.fields_to_plot = Ex Ey Ez Hx Hy Hz Bx By Bz Mx_xface My_xface Mz_xface Mx_yface My_yface Mz_yface Mx_zface My_zface Mz_zface
 plt.plot_raw_fields = 1


### PR DESCRIPTION
This includes an updated convergence test for the LLG paper.

The test consists of 3 traveling waves (one in each direction) with all material properties spatially varying in Gaussian profiles.

This includes Ms, Mx(t=0), alpha, gamma, sigma, epsilon.

Note mu has no effect, as it shouldn't since Ms>0 everywhere.

All variables (E, H, M) show clean second-order convergence in all norms.