### PR TITLE
Perturbation experiments

### DIFF
--- a/Source/Initialization/ReconnectionPerturbation.cpp
+++ b/Source/Initialization/ReconnectionPerturbation.cpp
@@ -71,16 +71,16 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
 #endif
     amrex::Print() << " Lx " << Lx << " " << Lz << "\n";
     amrex::Real xcs, B0, nd_ratio, delta, magnitude;
-    amrex::Real index_x = 2.0;
-    amrex::Real index_z = 1.0;
+    amrex::Real power_x = 2.0;
+    amrex::Real power_z = 1.0;
     ParmParse pp_warpx("warpx");
     pp_warpx.get("xcs", xcs);
     pp_warpx.get("B0", B0);
     pp_warpx.get("nd_ratio", nd_ratio);
     pp_warpx.get("delta", delta);
     pp_warpx.get("magnitude", magnitude);
-    pp_warpx.query("index_x", index_x);
-    pp_warpx.query("index_z", index_z);
+    pp_warpx.query("power_x", power_x);
+    pp_warpx.query("power_z", power_z);
 
     for ( MFIter mfi(*Bx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -109,9 +109,9 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
             amrex::ignore_unused(y);
             // Sinusoidal prefactor for the x-component of the perturbation
             // d(perturbation)/dz
-            amrex::Real prefactor = -(pi_val / Lz) * index_z * std::sin(pi_val/Lz * z)
-                                  * pow(std::cos(pi_val/Lz * z), index_z-1)
-                                  * pow(std::cos(pi_val/Lx * (x-xcs)), index_x);
+            amrex::Real prefactor = -(pi_val / Lz) * power_z * std::sin(pi_val/Lz * z)
+                                  * pow(std::cos(pi_val/Lz * z), power_z-1)
+                                  * pow(std::cos(pi_val/Lx * (x-xcs)), power_x);
 //                                  * std::cos(pi_val/Lx * (x-xcs))
 //                                  * std::cos(pi_val/Lx * (x-xcs));
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(
@@ -135,12 +135,12 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
 #endif
             amrex::ignore_unused(y);
             // d(perturbation)/dx
-            amrex::Real prefactor_term1 = (pi_val / Lx) * index_x * pow(std::cos(pi_val/Lz * z), index_z)
+            amrex::Real prefactor_term1 = (pi_val / Lx) * power_x * pow(std::cos(pi_val/Lz * z), power_z)
                                         * std::sin(pi_val/Lx * (x-xcs))
-                                        * pow(std::cos(pi_val/Lx * (x-xcs)),index_x-1);
+                                        * pow(std::cos(pi_val/Lx * (x-xcs)),power_x-1);
             // Original perturbation sinusoid
-            amrex::Real prefactor_term2 = -pow(std::cos(pi_val/Lz * z), index_z)
-                                        * pow(std::cos(pi_val/Lx * (x-xcs)), index_x);
+            amrex::Real prefactor_term2 = -pow(std::cos(pi_val/Lz * z), power_z)
+                                        * pow(std::cos(pi_val/Lx * (x-xcs)), power_x);
 //                                        * std::cos(pi_val/Lx * (x-xcs))
 //                                        * std::cos(pi_val/Lx * (x-xcs)) ;
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(

--- a/Source/Initialization/ReconnectionPerturbation.cpp
+++ b/Source/Initialization/ReconnectionPerturbation.cpp
@@ -71,12 +71,14 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
 #endif
     amrex::Print() << " Lx " << Lx << " " << Lz << "\n";
     amrex::Real xcs, B0, nd_ratio, delta, magnitude;
+    amrex::Real index = 2.0;
     ParmParse pp_warpx("warpx");
     pp_warpx.get("xcs", xcs);
     pp_warpx.get("B0", B0);
     pp_warpx.get("nd_ratio", nd_ratio);
     pp_warpx.get("delta", delta);
     pp_warpx.get("magnitude", magnitude);
+    pp_warpx.get("index", index);
 
     for ( MFIter mfi(*Bx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -103,9 +105,11 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
             amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
             amrex::ignore_unused(y);
+            // Sinusoidal prefactor for the x-component of the perturbation
             amrex::Real prefactor = -(pi_val / Lz) * std::sin(pi_val/Lz * z)
-                                  * std::cos(pi_val/Lx * (x-xcs))
-                                  * std::cos(pi_val/Lx * (x-xcs));
+                                  * pow(std::cos(pi_val/Lx * (x-xcs)), index);
+//                                  * std::cos(pi_val/Lx * (x-xcs))
+//                                  * std::cos(pi_val/Lx * (x-xcs));
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(
                                          x, z, pi_val, xcs, B0, nd_ratio, delta);
             Bx_array(i,j,k) += magnitude * prefactor * IntegralBz_val;
@@ -126,11 +130,13 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
             amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
             amrex::ignore_unused(y);
-            amrex::Real prefactor_term1 = (pi_val / Lx) * std::cos(pi_val/Lz * z)
-                                        * std::sin(2.*pi_val/Lx * (x-xcs));
+            amrex::Real prefactor_term1 = (pi_val / Lx) * index * std::cos(pi_val/Lz * z)
+                                        * std::sin(pi_val/Lx * (x-xcs))
+                                        * pow(std::cos(pi_val/Lx * (x-xcs)),index-1);
             amrex::Real prefactor_term2 = -std::cos(pi_val/Lz * z)
-                                        * std::cos(pi_val/Lx * (x-xcs))
-                                        * std::cos(pi_val/Lx * (x-xcs)) ;
+                                        * pow(std::cos(pi_val/Lx * (x-xcs)), index);
+//                                        * std::cos(pi_val/Lx * (x-xcs))
+//                                        * std::cos(pi_val/Lx * (x-xcs)) ;
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(
                                          x, z, pi_val, xcs, B0, nd_ratio, delta);
             Bz_array(i,j,k) += magnitude * ( prefactor_term1 * IntegralBz_val

--- a/Source/Initialization/ReconnectionPerturbation.cpp
+++ b/Source/Initialization/ReconnectionPerturbation.cpp
@@ -112,8 +112,6 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
             amrex::Real prefactor = -(pi_val / Lz) * power_z * std::sin(pi_val/Lz * z)
                                   * pow(std::cos(pi_val/Lz * z), power_z-1)
                                   * pow(std::cos(pi_val/Lx * (x-xcs)), power_x);
-//                                  * std::cos(pi_val/Lx * (x-xcs))
-//                                  * std::cos(pi_val/Lx * (x-xcs));
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(
                                          x, z, pi_val, xcs, B0, nd_ratio, delta);
             Bx_array(i,j,k) += magnitude * prefactor * IntegralBz_val;
@@ -141,8 +139,6 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
             // Original perturbation sinusoid
             amrex::Real prefactor_term2 = -pow(std::cos(pi_val/Lz * z), power_z)
                                         * pow(std::cos(pi_val/Lx * (x-xcs)), power_x);
-//                                        * std::cos(pi_val/Lx * (x-xcs))
-//                                        * std::cos(pi_val/Lx * (x-xcs)) ;
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(
                                          x, z, pi_val, xcs, B0, nd_ratio, delta);
             Bz_array(i,j,k) += magnitude * ( prefactor_term1 * IntegralBz_val

--- a/Source/Initialization/ReconnectionPerturbation.cpp
+++ b/Source/Initialization/ReconnectionPerturbation.cpp
@@ -71,14 +71,16 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
 #endif
     amrex::Print() << " Lx " << Lx << " " << Lz << "\n";
     amrex::Real xcs, B0, nd_ratio, delta, magnitude;
-    amrex::Real index = 2.0;
+    amrex::Real index_x = 2.0;
+    amrex::Real index_z = 1.0;
     ParmParse pp_warpx("warpx");
     pp_warpx.get("xcs", xcs);
     pp_warpx.get("B0", B0);
     pp_warpx.get("nd_ratio", nd_ratio);
     pp_warpx.get("delta", delta);
     pp_warpx.get("magnitude", magnitude);
-    pp_warpx.get("index", index);
+    pp_warpx.query("index_x", index_x);
+    pp_warpx.query("index_z", index_z);
 
     for ( MFIter mfi(*Bx, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -106,8 +108,10 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
 #endif
             amrex::ignore_unused(y);
             // Sinusoidal prefactor for the x-component of the perturbation
-            amrex::Real prefactor = -(pi_val / Lz) * std::sin(pi_val/Lz * z)
-                                  * pow(std::cos(pi_val/Lx * (x-xcs)), index);
+            // d(perturbation)/dz
+            amrex::Real prefactor = -(pi_val / Lz) * index_z * std::sin(pi_val/Lz * z)
+                                  * pow(std::cos(pi_val/Lz * z), index_z-1)
+                                  * pow(std::cos(pi_val/Lx * (x-xcs)), index_x);
 //                                  * std::cos(pi_val/Lx * (x-xcs))
 //                                  * std::cos(pi_val/Lx * (x-xcs));
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(
@@ -130,11 +134,13 @@ Reconnection_Perturbation::AddBfieldPerturbation (amrex::MultiFab *Bx,
             amrex::Real z = k*dx_lev[2] + real_box.lo(2) + fac_z;
 #endif
             amrex::ignore_unused(y);
-            amrex::Real prefactor_term1 = (pi_val / Lx) * index * std::cos(pi_val/Lz * z)
+            // d(perturbation)/dx
+            amrex::Real prefactor_term1 = (pi_val / Lx) * index_x * pow(std::cos(pi_val/Lz * z), index_z)
                                         * std::sin(pi_val/Lx * (x-xcs))
-                                        * pow(std::cos(pi_val/Lx * (x-xcs)),index-1);
-            amrex::Real prefactor_term2 = -std::cos(pi_val/Lz * z)
-                                        * pow(std::cos(pi_val/Lx * (x-xcs)), index);
+                                        * pow(std::cos(pi_val/Lx * (x-xcs)),index_x-1);
+            // Original perturbation sinusoid
+            amrex::Real prefactor_term2 = -pow(std::cos(pi_val/Lz * z), index_z)
+                                        * pow(std::cos(pi_val/Lx * (x-xcs)), index_x);
 //                                        * std::cos(pi_val/Lx * (x-xcs))
 //                                        * std::cos(pi_val/Lx * (x-xcs)) ;
             amrex::Real IntegralBz_val = Reconnection_Perturbation::IntegralBz(


### PR DESCRIPTION
Add runtime params for `warpx.power_x` and `warpx.power_z`. They control the functional form of the perturbation to the vector potential. The cosine in z is raised to `warpx.power_x` and the cosine in x is raised to `warpx.power_z`. The default is `warpx.power_x = 2` and `warpx.power_z = 1`. I've confirmed that the default initial B field matches the original perturbation.