### PR TITLE
Add user-defined particle attributes to parsers

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -106,7 +106,7 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
 
         git clone https://github.com/AMReX-Codes/amrex.git ../amrex
-        cd amrex && git checkout --detach 3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7 && cd -
+        cd amrex && git checkout --detach 1b73099a80e617696fc342fa8ac16e2d63ecab4b && cd -
         make COMP=gcc QED=FALSE USE_MPI=TRUE USE_GPU=TRUE USE_OMP=FALSE USE_PSATD=TRUE USE_CCACHE=TRUE -j 2
 
   build_nvhpc21-9-nvcc:

--- a/Regression/WarpX-GPU-tests.ini
+++ b/Regression/WarpX-GPU-tests.ini
@@ -60,7 +60,7 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/WarpX/ for more 
 
 [AMReX]
 dir = /home/regtester/git/amrex/
-branch = 3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7
+branch = 1b73099a80e617696fc342fa8ac16e2d63ecab4b
 
 [source]
 dir = /home/regtester/git/WarpX

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -59,7 +59,7 @@ emailBody = Check https://ccse.lbl.gov/pub/RegressionTesting/WarpX/ for more det
 
 [AMReX]
 dir = /home/regtester/AMReX_RegTesting/amrex/
-branch = 3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7
+branch = 1b73099a80e617696fc342fa8ac16e2d63ecab4b
 
 [source]
 dir = /home/regtester/AMReX_RegTesting/warpx

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.H
@@ -44,7 +44,7 @@ private:
     /** Parser function to be averaged by the functor. Arguments: x, y, z, ux, uy, uz */
     std::unique_ptr<amrex::Parser> m_map_fn_parser;
     /** Compiled #m_map_fn_parser */
-    amrex::ParserExecutor<6> m_map_fn;
+    amrex::ParserExecutor<7> m_map_fn;
 };
 
 #endif // WARPX_PARTICLEREDUCTIONFUNCTOR_H_

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
@@ -46,7 +46,7 @@ ParticleReductionFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, 
     ppc_mf.setVal(0._rt);
     auto& pc = warpx.GetPartContainer().GetParticleContainer(m_ispec);
     auto pcomps = pc.getParticleComps();
-    const int iupstream = pcomps["upstream"] - PIdx::nattrib;
+    const int iupstream = pcomps["upstream"] - PIdx::nattribs;
     // Copy over compiled parser function so that it can be captured by value in the lambda
     auto map_fn = m_map_fn;
     ParticleToMesh(pc, red_mf, m_lev,

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
@@ -26,7 +26,7 @@ ParticleReductionFunctor::ParticleReductionFunctor (const amrex::MultiFab* mf_sr
 
     // Allocate and compile a parser based on the input string fn_str
     m_map_fn_parser = std::make_unique<amrex::Parser>(makeParser(
-                fn_str, {"x", "y", "z", "ux", "uy", "uz", "us"}));
+                fn_str, {"x", "y", "z", "ux", "uy", "uz", "upstream"}));
     m_map_fn = m_map_fn_parser->compile<7>();
 }
 

--- a/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/ParticleReductionFunctor.cpp
@@ -26,8 +26,8 @@ ParticleReductionFunctor::ParticleReductionFunctor (const amrex::MultiFab* mf_sr
 
     // Allocate and compile a parser based on the input string fn_str
     m_map_fn_parser = std::make_unique<amrex::Parser>(makeParser(
-                fn_str, {"x", "y", "z", "ux", "uy", "uz"}));
-    m_map_fn = m_map_fn_parser->compile<6>();
+                fn_str, {"x", "y", "z", "ux", "uy", "uz", "us"}));
+    m_map_fn = m_map_fn_parser->compile<7>();
 }
 
 void
@@ -45,14 +45,18 @@ ParticleReductionFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, 
     red_mf.setVal(0._rt);
     ppc_mf.setVal(0._rt);
     auto& pc = warpx.GetPartContainer().GetParticleContainer(m_ispec);
+    auto pcomps = pc.getParticleComps();
+    const int iupstream = pcomps["upstream"] - PIdx::nattrib;
     // Copy over compiled parser function so that it can be captured by value in the lambda
     auto map_fn = m_map_fn;
     ParticleToMesh(pc, red_mf, m_lev,
-            [=] AMREX_GPU_DEVICE (const WarpXParticleContainer::SuperParticleType& p,
+            [=] AMREX_GPU_DEVICE (const WarpXParticleContainer::ParticleTileType::ConstParticleTileDataType& ptd,
+                const int pind,
                 amrex::Array4<amrex::Real> const& out_array,
                 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
                 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
             {
+                auto p = ptd.getSuperParticle(pind);
                 // Get position in WarpX convention to use in parser. Will be different from
                 // p.pos() for 1D and 2D simulations.
                 amrex::ParticleReal xw = 0._rt, yw = 0._rt, zw = 0._rt;
@@ -81,7 +85,8 @@ ParticleReductionFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, 
                 amrex::ParticleReal ux = p.rdata(PIdx::ux) / PhysConst::c;
                 amrex::ParticleReal uy = p.rdata(PIdx::uy) / PhysConst::c;
                 amrex::ParticleReal uz = p.rdata(PIdx::uz) / PhysConst::c;
-                amrex::Real value = map_fn(xw, yw, zw, ux, uy, uz);
+                amrex::ParticleReal upstream = ptd.m_runtime_rdata[iupstream][pind];
+                amrex::Real value = map_fn(xw, yw, zw, ux, uy, uz, upstream);
                 amrex::Gpu::Atomic::AddNoRet(&out_array(ii, jj, kk, 0), p.rdata(PIdx::w) * value);
             });
     // Add the weight for each particle -- total number of particles of this species

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -115,7 +115,7 @@ Diagnostics::BaseReadParameters ()
     std::string parser_str;
     amrex::ParmParse pp_diag_pfield(m_diag_name + ".particle_fields");
     for (const auto& var : m_pfield_varnames) {
-        Store_parserString(pp_diag_pfield, (var + "(x,y,z,ux,uy,uz)").c_str(), parser_str);
+        Store_parserString(pp_diag_pfield, (var + "(x,y,z,ux,uy,uz,us)").c_str(), parser_str);
         if (parser_str != "") {
             m_pfield_strings.insert({var, parser_str});
         }

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -115,7 +115,7 @@ Diagnostics::BaseReadParameters ()
     std::string parser_str;
     amrex::ParmParse pp_diag_pfield(m_diag_name + ".particle_fields");
     for (const auto& var : m_pfield_varnames) {
-        Store_parserString(pp_diag_pfield, (var + "(x,y,z,ux,uy,uz,us)").c_str(), parser_str);
+        Store_parserString(pp_diag_pfield, (var + "(x,y,z,ux,uy,uz,upstream)").c_str(), parser_str);
         if (parser_str != "") {
             m_pfield_strings.insert({var, parser_str});
         }

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -350,7 +350,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
         ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
-                                   compileParser<9>
+                                   compileParser<ParticleDiag::m_nvars>
                                        (particle_diags[i].m_particle_filter_parser.get()),
                                    pc->getMass(), rtmap);
         parser_filter.m_units = InputUnits::SI;

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -343,15 +343,16 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         int_flags.resize(pc->NumIntComps(), 1);
 
         pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
+        auto rtmap = pc->getParticleComps();
 
         RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                          particle_diags[i].m_random_fraction);
         UniformFilter const uniform_filter(particle_diags[i].m_do_uniform_filter,
                                            particle_diags[i].m_uniform_stride);
         ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
-                                   compileParser<ParticleDiag::m_nvars>
+                                   compileParser<9>
                                        (particle_diags[i].m_particle_filter_parser.get()),
-                                   pc->getMass());
+                                   pc->getMass(), rtmap);
         parser_filter.m_units = InputUnits::SI;
         GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                              particle_diags[i].m_diag_domain);
@@ -363,7 +364,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
             {
                 const SuperParticleType& p = src.getSuperParticle(ip);
                 return random_filter(p, engine) * uniform_filter(p, engine)
-                    * parser_filter(p, engine) * geometry_filter(p, engine);
+                    * parser_filter(src, ip, engine) * geometry_filter(p, engine);
             }, true);
         } else {
             PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.H
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.H
@@ -29,7 +29,7 @@ public:
     bool m_do_geom_filter    = false;
     amrex::Real m_random_fraction = 1.0;
     int m_uniform_stride = 1;
-    static constexpr int m_nvars = 7; // t, x, y, z, ux, uy, uz
+    static constexpr int m_nvars = 9; // t, x, y, z, ux, uy, uz, upstream, track
     std::unique_ptr<amrex::Parser> m_particle_filter_parser;
     amrex::RealBox m_diag_domain;
 

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -77,14 +77,14 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
     m_do_uniform_filter = queryWithParser(pp_diag_name_species_name, "uniform_stride",
                                                                      m_uniform_stride);
     std::string buf;
-    m_do_parser_filter = pp_diag_name_species_name.query("plot_filter_function(t,x,y,z,ux,uy,uz)",
+    m_do_parser_filter = pp_diag_name_species_name.query("plot_filter_function(t,x,y,z,ux,uy,uz,us,tr)",
                                                          buf);
 
     if (m_do_parser_filter) {
         std::string function_string = "";
-        Store_parserString(pp_diag_name_species_name,"plot_filter_function(t,x,y,z,ux,uy,uz)",
+        Store_parserString(pp_diag_name_species_name,"plot_filter_function(t,x,y,z,ux,uy,uz,us,tr)",
                            function_string);
         m_particle_filter_parser = std::make_unique<amrex::Parser>(
-            makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
+            makeParser(function_string,{"t","x","y","z","ux","uy","uz","us","tr"}));
     }
 }

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -77,14 +77,14 @@ ParticleDiag::ParticleDiag(std::string diag_name, std::string name, WarpXParticl
     m_do_uniform_filter = queryWithParser(pp_diag_name_species_name, "uniform_stride",
                                                                      m_uniform_stride);
     std::string buf;
-    m_do_parser_filter = pp_diag_name_species_name.query("plot_filter_function(t,x,y,z,ux,uy,uz,us,tr)",
+    m_do_parser_filter = pp_diag_name_species_name.query("plot_filter_function(t,x,y,z,ux,uy,uz,upstream,track)",
                                                          buf);
 
     if (m_do_parser_filter) {
         std::string function_string = "";
-        Store_parserString(pp_diag_name_species_name,"plot_filter_function(t,x,y,z,ux,uy,uz,us,tr)",
+        Store_parserString(pp_diag_name_species_name,"plot_filter_function(t,x,y,z,ux,uy,uz,upstream,track)",
                            function_string);
         m_particle_filter_parser = std::make_unique<amrex::Parser>(
-            makeParser(function_string,{"t","x","y","z","ux","uy","uz","us","tr"}));
+            makeParser(function_string,{"t","x","y","z","ux","uy","uz","upstream","track"}));
     }
 }

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.H
@@ -47,7 +47,7 @@ public:
     amrex::Real m_bin_size;
 
     /// Parser to read expression for particle quantity from the input file.
-    /// 7 elements are t, x, y, z, ux, uy, uz
+    /// 8 elements are t, x, y, z, ux, uy, uz, upstream
     static constexpr int m_nvars = 8;
     std::unique_ptr<amrex::Parser> m_parser;
 

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.H
@@ -48,7 +48,7 @@ public:
 
     /// Parser to read expression for particle quantity from the input file.
     /// 7 elements are t, x, y, z, ux, uy, uz
-    static constexpr int m_nvars = 7;
+    static constexpr int m_nvars = 8;
     std::unique_ptr<amrex::Parser> m_parser;
 
     /// Optional parser to filter particles before doing the histogram

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -67,10 +67,10 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     // read histogram function
     std::string function_string = "";
-    Store_parserString(pp_rd_name,"histogram_function(t,x,y,z,ux,uy,uz)",
+    Store_parserString(pp_rd_name,"histogram_function(t,x,y,z,ux,uy,uz,us)",
                        function_string);
     m_parser = std::make_unique<amrex::Parser>(
-        makeParser(function_string,{"t","x","y","z","ux","uy","uz"}));
+        makeParser(function_string,{"t","x","y","z","ux","uy","uz","us"}));
 
     // read normalization type
     std::string norm_string = "default";
@@ -107,12 +107,12 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     // Read optional filter
     std::string buf;
-    m_do_parser_filter = pp_rd_name.query("filter_function(t,x,y,z,ux,uy,uz)", buf);
+    m_do_parser_filter = pp_rd_name.query("filter_function(t,x,y,z,ux,uy,uz,us)", buf);
     if (m_do_parser_filter) {
         std::string filter_string = "";
-        Store_parserString(pp_rd_name,"filter_function(t,x,y,z,ux,uy,uz)", filter_string);
+        Store_parserString(pp_rd_name,"filter_function(t,x,y,z,ux,uy,uz,us)", filter_string);
         m_parser_filter = std::make_unique<amrex::Parser>(
-                                     makeParser(filter_string,{"t","x","y","z","ux","uy","uz"}));
+                                     makeParser(filter_string,{"t","x","y","z","ux","uy","uz","us"}));
     }
 
     // resize data array
@@ -178,6 +178,9 @@ void ParticleHistogram::ComputeDiags (int step)
         (m_norm == NormalizationType::unity_particle_weight) ? true : false;
 
     bool const do_parser_filter = m_do_parser_filter;
+    // figure out which particle attribute is upstream
+    auto pcomps = myspc.getParticleComps();
+    const int iupstream = pcomps["upstream"];
 
     // zero-out old data on the host
     std::fill(m_data.begin(), m_data.end(), amrex::Real(0.0));
@@ -199,6 +202,7 @@ void ParticleHistogram::ComputeDiags (int step)
                 Real* const AMREX_RESTRICT d_ux = attribs[PIdx::ux].dataPtr();
                 Real* const AMREX_RESTRICT d_uy = attribs[PIdx::uy].dataPtr();
                 Real* const AMREX_RESTRICT d_uz = attribs[PIdx::uz].dataPtr();
+                Real* const AMREX_RESTRICT d_ups = pti.GetAttribs(iupstream).dataPtr();
 
                 long const np = pti.numParticles();
 
@@ -212,13 +216,14 @@ void ParticleHistogram::ComputeDiags (int step)
                     auto const ux = d_ux[i] / PhysConst::c;
                     auto const uy = d_uy[i] / PhysConst::c;
                     auto const uz = d_uz[i] / PhysConst::c;
+                    auto const upstream = d_ups[i];
 
                     // don't count a particle if it is filtered out
                     if (do_parser_filter)
-                        if (!fun_filterparser(t, x, y, z, ux, uy, uz))
+                        if (!fun_filterparser(t, x, y, z, ux, uy, uz,upstream))
                             return;
                     // continue function if particle is not filtered out
-                    auto const f = fun_partparser(t, x, y, z, ux, uy, uz);
+                    auto const f = fun_partparser(t, x, y, z, ux, uy, uz,upstream);
 
                     // determine particle bin
                     int const bin = int(Math::floor((f-bin_min)/bin_size));

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -67,10 +67,10 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     // read histogram function
     std::string function_string = "";
-    Store_parserString(pp_rd_name,"histogram_function(t,x,y,z,ux,uy,uz,us)",
+    Store_parserString(pp_rd_name,"histogram_function(t,x,y,z,ux,uy,uz,upstream)",
                        function_string);
     m_parser = std::make_unique<amrex::Parser>(
-        makeParser(function_string,{"t","x","y","z","ux","uy","uz","us"}));
+        makeParser(function_string,{"t","x","y","z","ux","uy","uz","upstream"}));
 
     // read normalization type
     std::string norm_string = "default";
@@ -107,12 +107,12 @@ ParticleHistogram::ParticleHistogram (std::string rd_name)
 
     // Read optional filter
     std::string buf;
-    m_do_parser_filter = pp_rd_name.query("filter_function(t,x,y,z,ux,uy,uz,us)", buf);
+    m_do_parser_filter = pp_rd_name.query("filter_function(t,x,y,z,ux,uy,uz,upstream)", buf);
     if (m_do_parser_filter) {
         std::string filter_string = "";
-        Store_parserString(pp_rd_name,"filter_function(t,x,y,z,ux,uy,uz,us)", filter_string);
+        Store_parserString(pp_rd_name,"filter_function(t,x,y,z,ux,uy,uz,upstream)", filter_string);
         m_parser_filter = std::make_unique<amrex::Parser>(
-                                     makeParser(filter_string,{"t","x","y","z","ux","uy","uz","us"}));
+                                     makeParser(filter_string,{"t","x","y","z","ux","uy","uz","upstream"}));
     }
 
     // resize data array

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -607,7 +607,6 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
                                            particle_diags[i].m_diag_domain);
 
       if (! isBTD) {
-          auto rtmap = pc->getParticleComps();
           using SrcData = WarpXParticleContainer::ParticleTileType::ConstParticleTileDataType;
           tmp.copyParticles(*pc,
                             [=] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip, const amrex::RandomEngine& engine)

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -592,7 +592,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     int_flags.resize(pc->NumIntComps(), 1);
 
       pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
-        auto rtmap = pc->getParticleComps();
+      auto rtmap = pc->getParticleComps();
 
       RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                        particle_diags[i].m_random_fraction);

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -592,6 +592,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
     int_flags.resize(pc->NumIntComps(), 1);
 
       pc->ConvertUnits(ConvertDirection::WarpX_to_SI);
+        auto rtmap = pc->getParticleComps();
 
       RandomFilter const random_filter(particle_diags[i].m_do_random_filter,
                                        particle_diags[i].m_random_fraction);
@@ -600,7 +601,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
       ParserFilter parser_filter(particle_diags[i].m_do_parser_filter,
                                  compileParser<9>
                                      (particle_diags[i].m_particle_filter_parser.get()),
-                                 pc->getMass());
+                                 pc->getMass(), rtmap);
       parser_filter.m_units = InputUnits::SI;
       GeometryFilter const geometry_filter(particle_diags[i].m_do_geom_filter,
                                            particle_diags[i].m_diag_domain);
@@ -613,7 +614,7 @@ WarpXOpenPMDPlot::WriteOpenPMDParticles (const amrex::Vector<ParticleDiag>& part
           {
               const SuperParticleType& p = src.getSuperParticle(ip);
               return random_filter(p, engine) * uniform_filter(p, engine)
-                     * parser_filter(src, p, rtmap, engine) * geometry_filter(p, engine);
+                     * parser_filter(src, ip, engine) * geometry_filter(p, engine);
           }, true);
       } else if (isBTD) {
           PinnedMemoryParticleContainer* pinned_pc = particle_diags[i].getPinnedParticleContainer();

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -17,6 +17,7 @@
 #include <AMReX_Random.H>
 
 using SuperParticleType = typename WarpXParticleContainer::SuperParticleType;
+using TileType = typename WarpXParticleContainer::ParticleTileType::ConstParticleTileDataType;
 
 /**
  *  \brief Used to keep track of what inputs units a filter function should expect.
@@ -93,13 +94,15 @@ struct ParserFilter
 {
     /** constructor
      * \param a_is_active whether the test is active
-     * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a value > 0.5 for selected particle
+     * \param a_filter_parser parser taking t, x, y, z, ux, uy, uz, upstream, track and returning a value > 0.5 for selected particle
      * \param a_mass mass of the particle species
      */
-    ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
-                 amrex::Real a_mass)
+    ParserFilter(bool a_is_active, amrex::ParserExecutor<9> const& a_filter_parser,
+                 amrex::Real a_mass, std::map<std::string, int>& a_rt_param_map)
         : m_is_active(a_is_active), m_function_partparser(a_filter_parser), m_mass(a_mass)
     {
+        m_ius = a_rt_param_map["upstream"] - PIdx::nattribs;
+        m_itr = a_rt_param_map["track"] - PIdx::nattribs;
         m_t = WarpX::GetInstance().gett_new(0);
         m_units = InputUnits::WarpX;
     }
@@ -125,15 +128,45 @@ struct ParserFilter
             uz /= m_mass;
         }
         // ux, uy, uz are now in beta*gamma
-        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz) > 0.5 ) return 1;
+        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz,0.0,0.0) > 0.5 ) return 1;
+        else return 0;
+    }
+    /**
+     * \brief return 1 if the particle is selected by the parser
+     * \param p one particle
+     * \return whether or not the particle is selected
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool operator () (const TileType& ptd, const int ip, const amrex::RandomEngine&) const noexcept
+    {
+        if ( !m_is_active ) return 1;
+        auto p = ptd.getSuperParticle(ip);
+        amrex::ParticleReal x, y, z;
+        get_particle_position(p, x, y, z);
+        amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
+        amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
+        amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
+        amrex::Real us = ptd.m_runtime_rdata[m_ius][ip];
+        amrex::Real tr = ptd.m_runtime_rdata[m_itr][ip];
+        if (m_units == InputUnits::SI)
+        {
+            ux /= m_mass;
+            uy /= m_mass;
+            uz /= m_mass;
+        }
+        // ux, uy, uz are now in beta*gamma
+        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz,us,tr) > 0.5 ) return 1;
         else return 0;
     }
 private:
     /** Whether this diagnostics is activated. Select all particles if false */
     const bool m_is_active;
+    /** Record indices of user-defined vars */
+    int m_ius;
+    int m_itr;
 public:
-    /** Parser function with 7 input variables, t,x,y,z,ux,uy,uz */
-    amrex::ParserExecutor<7> const m_function_partparser;
+    /** Parser function with 9 input variables, t,x,y,z,ux,uy,uz,upstream,track */
+    amrex::ParserExecutor<9> const m_function_partparser;
     /** Store physical time. */
     amrex::Real m_t;
     /** Mass of particle species */

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -146,8 +146,8 @@ struct ParserFilter
         amrex::Real ux = p.rdata(PIdx::ux)/PhysConst::c;
         amrex::Real uy = p.rdata(PIdx::uy)/PhysConst::c;
         amrex::Real uz = p.rdata(PIdx::uz)/PhysConst::c;
-        amrex::Real us = ptd.m_runtime_rdata[m_ius][ip];
-        amrex::Real tr = ptd.m_runtime_rdata[m_itr][ip];
+        amrex::Real upstream = ptd.m_runtime_rdata[m_ius][ip];
+        amrex::Real track = ptd.m_runtime_rdata[m_itr][ip];
         if (m_units == InputUnits::SI)
         {
             ux /= m_mass;
@@ -155,7 +155,7 @@ struct ParserFilter
             uz /= m_mass;
         }
         // ux, uy, uz are now in beta*gamma
-        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz,us,tr) > 0.5 ) return 1;
+        if ( m_function_partparser(m_t,x,y,z,ux,uy,uz,upstream,track) > 0.5 ) return 1;
         else return 0;
     }
 private:

--- a/Tools/ReconnectionInputAndTools/inputs_reconnection_s30_attr.2d
+++ b/Tools/ReconnectionInputAndTools/inputs_reconnection_s30_attr.2d
@@ -1,0 +1,210 @@
+#################################
+########### CONSTANTS ###########
+#################################
+my_constants.nde = 2.82395872706189E+017
+my_constants.ndi = 2.82395872706189E+017
+my_constants.nbe = 5.64791745412378E+016
+my_constants.nbi = 5.64791745412378E+016
+my_constants.delta = 0.05
+my_constants.B0 = 0.4175177341
+my_constants.xcs = 4.48
+my_constants.dout = 8.96 * 2. / 7168. * 5
+#my_constants.pi = 3.14159265358979
+my_constants.B_prefactor = 2 * B0 / (pi/2 + nde/nbe -1)
+my_constants.sigma = B0 * B0 / (mu0 * nbe * m_e * clight * clight)
+my_constants.lambda_e = clight / q_e * (m_e * epsilon0 / nde) ** 0.5
+my_constants.eta = 200 # theta_b = sigma / eta
+my_constants.ds = 8 # half-width of initial downstream region, in units of delta
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 15000
+amr.n_cell = 7168 3456 # nboxes : 56 * 27 = 1512 (check with 42 nodes=252 (6boxes/gpu))
+amr.max_grid_size_x = 128
+amr.max_grid_size_y = 128
+amr.blocking_factor = 32
+amr.max_level = 0
+geometry.dims = 2
+boundary.field_lo = periodic periodic
+boundary.field_hi = periodic periodic
+geometry.prob_lo     = -8.96   -4.32
+geometry.prob_hi     =  8.96    4.32
+#################################
+############ NUMERICS ###########
+#################################
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+warpx.cfl = 0.95
+#amr.restart = diags/check10000
+algo.particle_shape = 3
+algo.load_balance_intervals = 100
+algo.load_balance_with_sfc = 1
+algo.load_balance_costs_update = Heuristic
+algo.load_balance_efficiency_ratio_threshold = 1.01
+algo.load_balance_knapsack_factor = 2.0
+algo.maxwell_solver = psatd
+algo.current_deposition = esirkepov
+algo.field_gathering = energy-conserving
+warpx.use_filter = 1
+#################################
+########## DIAGNOSTICS ##########
+#################################
+diagnostics.diags_names = diags diags_part diags_track check
+diags.intervals = 50
+diags.diag_type = Full
+diags.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho_electrons divB divE
+diags.write_species=0
+
+diags_part.intervals = 500
+diags_part.diag_type = Full
+diags_part.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho_electrons divB divE
+diags_part.ions.random_fraction = 0.1
+diags_part.electrons.random_fraction = 0.1
+
+diags_track.intervals = 1
+diags_track.diag_type = Full
+diags_track.fields_to_plot = Ex #output minimum number of fields
+diags_track.ions.plot_filter_function(t,x,y,z,ux,uy,uz,us,tr) = tr
+diags_track.electrons.plot_filter_function(t,x,y,z,ux,uy,uz,us,tr) = tr
+
+diags.particle_fields_to_plot = ux uy uz uxsq uysq uzsq energy upstream
+diags.particle_fields.ux(x,y,z,ux,uy,uz,us) = ux / sqrt(1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.uy(x,y,z,ux,uy,uz,us) = uy / sqrt(1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.uz(x,y,z,ux,uy,uz,us) = uz / sqrt(1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.uxsq(x,y,z,ux,uy,uz,us) = ux * ux / (1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.uysq(x,y,z,ux,uy,uz,us) = uy * uy / (1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.uzsq(x,y,z,ux,uy,uz,us) = uz * uz / (1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.energy(x,y,z,ux,uy,uz,us) = sqrt(1 + ux * ux + uy * uy + uz * uz)
+diags.particle_fields.upstream(x,y,z,ux,uy,uz,us) = us
+diags.particle_fields_species = ions electrons
+
+check.intervals = 5000
+check.diag_type = Full
+check.format = checkpoint
+
+electrons.addRealAttributes = upstream track
+electrons.attribute.upstream(x,y,z,ux,uy,uz,t) = 1 - heaviside((x-xcs) + delta * ds,0) * heaviside(-(x-xcs)+delta * ds,0) - heaviside(-(x+xcs)+delta*ds,0)*heaviside(x+xcs+delta * ds,0)
+electrons.attribute.track(x,y,z,ux,uy,uz,t) = heaviside((x-xcs-0.5),0) * heaviside(-(x-xcs-0.5)+delta,0)
+ions.addRealAttributes = upstream track
+ions.attribute.upstream(x,y,z,ux,uy,uz,t) = 1 - heaviside((x-xcs) + delta * ds,0) * heaviside(-(x-xcs)+delta * ds,0) - heaviside(-(x+xcs)+delta*ds,0)*heaviside(x+xcs+delta * ds,0)
+ions.attribute.track(x,y,z,ux,uy,uz,t) = heaviside((x-xcs-0.5),0) * heaviside(-(x-xcs-0.5)+delta,0)
+
+
+warpx.reduced_diags_names = LBCost LBEfficiency PEnergy PMomentum EMEnergy EMMomentum LogEnergyHE LogEnergyHI EnergyHE EnergyHI Bsq LogEnergyHEus LogEnergyHIus
+LBCost.type = LoadBalanceCosts
+LBCost.intervals = 20
+LBEfficiency.type = LoadBalanceEfficiency
+LBEfficiency.intervals = 20
+PEnergy.type = ParticleEnergy
+PEnergy.intervals = 20
+EMEnergy.type = FieldEnergy
+EMEnergy.intervals = 20
+PMomentum.type = ParticleMomentum
+PMomentum.intervals = 20
+EMMomentum.type = FieldMomentum
+EMMomentum.intervals = 20
+
+LogEnergyHEus.type = ParticleHistogram
+LogEnergyHEus.species = "electrons"
+LogEnergyHEus.intervals = 20
+LogEnergyHEus.histogram_function(t,x,y,z,ux,uy,uz,us) = "log10(sqrt(1.0+(ux*ux + uy*uy + uz*uz)))"
+LogEnergyHEus.filter_function(t,x,y,z,ux,uy,uz,us) = "us"
+LogEnergyHEus.bin_number = 100
+LogEnergyHEus.bin_min = 0
+LogEnergyHEus.bin_max = 3
+
+LogEnergyHIus.type = ParticleHistogram
+LogEnergyHIus.species = "electrons"
+LogEnergyHIus.intervals = 20
+LogEnergyHIus.histogram_function(t,x,y,z,ux,uy,uz,us) = "log10(sqrt(1.0+(ux*ux + uy*uy + uz*uz)))"
+LogEnergyHIus.filter_function(t,x,y,z,ux,uy,uz,us) = "us"
+LogEnergyHIus.bin_number = 100
+LogEnergyHIus.bin_min = 0
+LogEnergyHIus.bin_max = 3
+
+LogEnergyHE.type = ParticleHistogram
+LogEnergyHE.species = "electrons"
+LogEnergyHE.intervals = 20
+LogEnergyHE.histogram_function(t,x,y,z,ux,uy,uz,us) = "log10(sqrt(1.0+(ux*ux + uy*uy + uz*uz)))"
+LogEnergyHE.bin_number = 100
+LogEnergyHE.bin_min = 0
+LogEnergyHE.bin_max = 3
+
+LogEnergyHI.type = ParticleHistogram
+LogEnergyHI.species = "ions"
+LogEnergyHI.intervals = 20
+LogEnergyHI.histogram_function(t,x,y,z,ux,uy,uz,us) = "log10(sqrt(1.0+(ux*ux + uy*uy + uz*uz)))"
+LogEnergyHI.bin_number = 100
+LogEnergyHI.bin_min = 0
+LogEnergyHI.bin_max = 3
+
+EnergyHE.type = ParticleHistogram
+EnergyHE.species = "electrons"
+EnergyHE.intervals = 20
+EnergyHE.histogram_function(t,x,y,z,ux,uy,uz,us) = "sqrt(1.0+(ux*ux + uy*uy + uz*uz))"
+EnergyHE.bin_number = 50
+EnergyHE.bin_min = 1
+EnergyHE.bin_max = 2
+
+EnergyHI.type = ParticleHistogram
+EnergyHI.species = "ions"
+EnergyHI.intervals = 20
+EnergyHI.histogram_function(t,x,y,z,ux,uy,uz,us) = "sqrt(1.0+(ux*ux + uy*uy + uz*uz))"
+EnergyHI.bin_number = 50
+EnergyHI.bin_min = 1
+EnergyHI.bin_max = 2
+
+Bsq.type = FieldReduction
+Bsq.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz) = Bx*Bx + By*By + Bz*Bz
+Bsq.reduction_type = Integral
+Bsq.intervals = 20
+
+#################################
+############ FIELD ##############
+#################################
+warpx.B_ext_grid_init_style="parse_B_ext_grid_function"
+warpx.Bx_external_grid_function(x,y,z) = "0"
+warpx.By_external_grid_function(x,y,z) = "0"
+warpx.Bz_external_grid_function(x,y,z) = "-1* B0 * 2. / (pi/2. + 5. - 1.) * (atan(tanh((x+xcs)/2./delta)) - atan(tanh((x-xcs)/2./delta)) - pi/4. + 1./2. * (5. - 1.) * (tanh((x+xcs)/delta) - tanh((x-xcs)/delta) - 1.) )"
+warpx.IncludeBfieldPerturbation = 1
+warpx.xcs = 4.48
+warpx.B0 = 0.4175177341
+warpx.nd_ratio = 5. #nde / nbe + 0.
+warpx.delta = 0.05 #delta + 0.
+warpx.magnitude = 0.01
+warpx.power_x = 2
+warpx.power_z = 51
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = electrons ions
+electrons.charge = -q_e
+electrons.mass = m_e
+electrons.injection_style = "NUniformPerCell"
+electrons.num_particles_per_cell_each_dim = 8 8
+electrons.profile = parse_density_function
+electrons.density_function(x,y,z) = "nbe* (1+(nde/nbe - 1) * (1/cosh((x+xcs)/delta) + 1/cosh((x-xcs)/delta)))"
+electrons.momentum_distribution_type = maxwell_juttner
+electrons.theta_distribution_type = "parser"
+electrons.theta_function(x,y,z) = "sigma / 4 * ((4+eta)/(eta) - (B_prefactor / B0 * (atan(tanh((x-xcs)/(2 * delta))) - atan(tanh((x+xcs)/(2 * delta))) + pi/4 + 0.5 * (nde/nbe - 1) * (tanh((x-xcs)/delta) - tanh((x+xcs)/delta) + 1))) ** 2) / ((1+(nde/nbe - 1) * (1/cosh((x+xcs)/delta) + 1/cosh((x-xcs)/delta))) * (1 - (lambda_e * sigma ** 0.5 / (2 * delta * (pi/2 + nde/nbe - 1)) * (nde/nbe) ** 0.5 * (1/cosh((x+xcs)/delta) - 1/cosh((x-xcs)/delta)))**2) ** 0.5)"
+electrons.beta_distribution_type = "parser"
+electrons.beta_function(x,y,z) = "lambda_e * sigma ** 0.5 / (2 * delta * (pi/2 + nde/nbe - 1)) * (nde/nbe) ** 0.5 * (1/cosh((x+xcs)/delta) - 1/cosh((x-xcs)/delta))"
+electrons.bulk_vel_dir = -y
+electrons.cell_centered = true
+electrons.cell_size = 0.0025
+
+ions.charge = q_e
+ions.mass = m_e
+ions.injection_style = "NUniformPerCell"
+ions.num_particles_per_cell_each_dim = 8 8
+ions.profile = parse_density_function
+ions.density_function(x,y,z) = "nbi + (ndi-nbi) * (cosh((x + xcs)/delta)**-1 + cosh((x - xcs)/delta)**-1)"
+ions.theta_distribution_type = "parser"
+ions.theta_function(x,y,z) = "sigma / 4 * ((4+eta)/(eta) - (B_prefactor / B0 * (atan(tanh((x-xcs)/(2 * delta))) - atan(tanh((x+xcs)/(2 * delta))) + pi/4 + 0.5 * (nde/nbe - 1) * (tanh((x-xcs)/delta) - tanh((x+xcs)/delta) + 1))) ** 2) / ((1+(nde/nbe - 1) * (1/cosh((x+xcs)/delta) + 1/cosh((x-xcs)/delta))) * (1 - (lambda_e * sigma ** 0.5 / (2 * delta * (pi/2 + nde/nbe - 1)) * (nde/nbe) ** 0.5 * (1/cosh((x+xcs)/delta) - 1/cosh((x-xcs)/delta)))**2) ** 0.5)"
+ions.density_function(x,y,z) = "nbe * (1+(nde/nbe - 1) * (1/cosh((x+xcs)/delta) + 1/cosh((x-xcs)/delta)))"
+ions.beta_distribution_type = "parser"
+ions.beta_function(x,y,z) = "lambda_e * sigma ** 0.5 / (2 * delta * (pi/2 + nde/nbe - 1)) * (nde/nbe) ** 0.5 * (1/cosh((x+xcs)/delta) - 1/cosh((x-xcs)/delta))"
+ions.momentum_distribution_type = maxwell_juttner
+ions.bulk_vel_dir = y
+ions.cell_size = 0.0025
+ions.cell_centered = true

--- a/Tools/ReconnectionInputAndTools/inputs_reconnection_s30_attr.2d
+++ b/Tools/ReconnectionInputAndTools/inputs_reconnection_s30_attr.2d
@@ -64,8 +64,8 @@ diags_part.electrons.random_fraction = 0.1
 diags_track.intervals = 1
 diags_track.diag_type = Full
 diags_track.fields_to_plot = Ex #output minimum number of fields
-diags_track.ions.plot_filter_function(t,x,y,z,ux,uy,uz,us,tr) = tr
-diags_track.electrons.plot_filter_function(t,x,y,z,ux,uy,uz,us,tr) = tr
+diags_track.ions.plot_filter_function(t,x,y,z,ux,uy,uz,us,track) = track
+diags_track.electrons.plot_filter_function(t,x,y,z,ux,uy,uz,us,track) = track
 
 diags.particle_fields_to_plot = ux uy uz uxsq uysq uzsq energy upstream
 diags.particle_fields.ux(x,y,z,ux,uy,uz,us) = ux / sqrt(1 + ux * ux + uy * uy + uz * uz)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -237,7 +237,7 @@ set(WarpX_amrex_src ""
 set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
-set(WarpX_amrex_branch "3c5afdc9dd15af28523d1c7ea16909b3bb3f67d7"
+set(WarpX_amrex_branch "1b73099a80e617696fc342fa8ac16e2d63ecab4b"
     CACHE STRING
     "Repository branch for WarpX_amrex_repo if(WarpX_amrex_internal)")
 


### PR DESCRIPTION
Add one user-defined attribute (upstream) to `ParticleReductionFunctor` and histograms. Add two user-defined attributes (upstream and track) to plotfile and OpenPMD particle output. 