### PR TITLE
fix restart for init pulsar data and conductor

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/EdotBFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/EdotBFunctor.cpp
@@ -15,7 +15,9 @@ EdotBFunctor::EdotBFunctor (amrex::MultiFab const * Ex_src, amrex::MultiFab cons
     : ComputeDiagFunctor(ncomp, crse_ratio), m_Ex_src(Ex_src), m_Ey_src(Ey_src),
       m_Ez_src(Ez_src), m_Bx_src(Bx_src), m_By_src(By_src), m_Bz_src(Bz_src),
       m_lev(lev)
-{}
+{
+    amrex::ignore_unused(m_lev);
+}
 
 void
 EdotBFunctor::operator ()(amrex::MultiFab& mf_dst, int dcomp, const int /*i_buffer=0*/) const

--- a/Source/Diagnostics/ComputeDiagFunctors/PoyntingVectorFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/PoyntingVectorFunctor.cpp
@@ -18,7 +18,9 @@ PoyntingVectorFunctor::PoyntingVectorFunctor (
     : ComputeDiagFunctor(ncomp, crse_ratio), m_Ex_src(Ex_src), m_Ey_src(Ey_src),
       m_Ez_src(Ez_src), m_Bx_src(Bx_src), m_By_src(By_src), m_Bz_src(Bz_src),
       m_lev(lev), m_vectorcomp(vectorcomp)
-{}
+{
+    amrex::ignore_unused(m_lev);
+}
 
 void
 PoyntingVectorFunctor::operator ()(amrex::MultiFab& mf_dst,

--- a/Source/Diagnostics/ComputeDiagFunctors/SphericalComponentFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/SphericalComponentFunctor.cpp
@@ -22,7 +22,9 @@ SphericalComponentFunctor::SphericalComponentFunctor (amrex::MultiFab const * mf
     : ComputeDiagFunctor(ncomp, crse_ratio), m_mfx_src(mfx_src),
       m_mfy_src(mfy_src), m_mfz_src(mfz_src), m_lev(lev), m_sphericalcomp(sphericalcomp),
       m_Efield(Efield)
-{}
+{
+    amrex::ignore_unused(m_lev, m_sphericalcomp, m_Efield);
+}
 
 
 void

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
@@ -68,7 +68,7 @@ public:
 
 
     /**
-     * This function does the actual reduction computation. 
+     * This function does the actual reduction computation.
      * The reduction operation is performed on the raw fields using amrex::ReduceOps.
      *
      * \tparam ReduceOp the type of reduction that is performed. This is typically
@@ -82,8 +82,8 @@ public:
         auto & warpx = WarpX::GetInstance();
         const auto nLevel = 1;
         auto reduction_function_parser = m_parser->compile<m_nvars>();
-        int integral_type = m_integral_type;        
-        
+        int integral_type = m_integral_type;
+
         for (int lev = 0; lev < nLevel; ++lev) {
             const amrex::MultiFab &Ex = warpx.getEfield(lev,0);
             const amrex::MultiFab &Ey = warpx.getEfield(lev,1);
@@ -130,7 +130,7 @@ public:
                 const amrex::Box& tx = mfi.tilebox(Ex_nodalType);
                 const amrex::Box& ty = mfi.tilebox(Ey_nodalType);
                 const amrex::Box& tz = mfi.tilebox(Ez_nodalType);
- 
+
                 const amrex::IntVect lx = tx.smallEnd() ;
                 const amrex::IntVect hx = tx.bigEnd()   - amrex::IntVect::TheNodeVector();
                 const amrex::Box& tex = amrex::Box(lx,hx,Ex_nodalType);
@@ -142,7 +142,7 @@ public:
                 const amrex::IntVect lz = tz.smallEnd() ;
                 const amrex::IntVect hz = tz.bigEnd()   - amrex::IntVect::TheNodeVector();
                 const amrex::Box& tez = amrex::Box(lz,hz,Ez_nodalType);
- 
+
                 const auto& Ex_arr = Ex[mfi].array();
                 const auto& Ey_arr = Ey[mfi].array();
                 const auto& Ez_arr = Ez[mfi].array();
@@ -168,7 +168,7 @@ public:
                 reduceEy_op.eval(tey, reduceEy_data,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) ->ReduceTuple
                 {
-                    // Shift x, y, z position based on index type 
+                    // Shift x, y, z position based on index type
                     amrex::Real fac_x = (1._rt - Ey_nodalType[0]) * dx[0] * 0.5_rt;
                     amrex::Real x = i * dx[0] + real_box.lo(0) + fac_x;
 #if (AMREX_SPACEDIM==2)
@@ -186,7 +186,7 @@ public:
                 reduceEz_op.eval(tez, reduceEz_data,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) ->ReduceTuple
                 {
-                    // Shift x, y, z position based on index type 
+                    // Shift x, y, z position based on index type
                     amrex::Real fac_x = (1._rt - Ez_nodalType[0]) * dx[0] * 0.5_rt;
                     amrex::Real x = i * dx[0] + real_box.lo(0) + fac_x;
 #if (AMREX_SPACEDIM==2)
@@ -254,7 +254,7 @@ public:
             m_data[index_Ex] = reducedEx_value;
             m_data[index_Ey] = reducedEy_value;
             m_data[index_Ez] = reducedEz_value;
-           
+
         }
     }
 

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.H
@@ -77,6 +77,7 @@ public:
     template<typename ReduceOp>
     void ComputeRawEFieldReduction()
     {
+#ifndef WARPX_DIM_RZ
         using namespace amrex::literals;
 
         auto & warpx = WarpX::GetInstance();
@@ -256,8 +257,8 @@ public:
             m_data[index_Ez] = reducedEz_value;
 
         }
+#endif
     }
-
 };
 
 #endif

--- a/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/RawEFieldReduction.cpp
@@ -26,7 +26,7 @@ RawEFieldReduction::RawEFieldReduction (std::string rd_name)
 : ReducedDiags{rd_name}
 {
     using namespace amrex::literals;
-
+    amrex::ignore_unused(m_surface_normal);
     // RZ coordinate is not working
 #if (defined WARPX_DIM_RZ)
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -13,6 +13,7 @@
 #endif
 #include "FieldIO.H"
 #include "Particles/MultiParticleContainer.H"
+#include "Particles/PulsarParameters.H"
 #include "Parallelization/WarpXCommUtil.H"
 #include "Utils/CoarsenIO.H"
 #include "Utils/TextMsg.H"
@@ -344,6 +345,9 @@ WarpX::InitFromCheckpoint ()
         }
     }
 
+#ifdef PULSAR
+    m_pulsar->InitDataAtRestart();
+#endif
     InitializeEBGridData(maxLevel());
 
     // Initialize particles

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -378,7 +378,10 @@ WarpX::InitData ()
     }
 
 #ifdef PULSAR
-    m_pulsar->InitData();
+    if (restart_chkfile.empty()) {
+        // Inititalize pulsar data
+        m_pulsar->InitData();
+    }
 #endif
 
     InitDiagnostics();

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -894,7 +894,7 @@ PhysicalParticleContainer::AddPlasma (int lev, RealBox part_realbox)
                     // instead of modiying number of particles, the weight is changed
                     pcounts[index] = num_ppc;
                 } else if (pulsar_modifyParticleWtAtInjection == 0) {
-		    const amrex::XDim3 ppc_per_dim = inj_pos->getppcInEachDim();
+            const amrex::XDim3 ppc_per_dim = inj_pos->getppcInEachDim();
                     // Modiying number of particles injected
                     // (could lead to round-off errors)
                     pcounts[index] = static_cast<int>(ppc_per_dim.x*std::cbrt(pulsar_injection_fraction))

--- a/Source/Particles/PulsarParameters.H
+++ b/Source/Particles/PulsarParameters.H
@@ -21,6 +21,7 @@ public:
 
     static void ReadParameters();
     void InitData ();
+    void InitDataAtRestart ();
     void InitializeConductorMultifabUsingParser(amrex::MultiFab *mf,
          amrex::ParserExecutor<3> const& conductor_parser, const int lev);
 

--- a/Source/Particles/PulsarParameters.H
+++ b/Source/Particles/PulsarParameters.H
@@ -266,7 +266,7 @@ public:
                                          amrex::ParticleReal &Byp, amrex::ParticleReal &Bzp)
     {
         // enfore theory on particle for r <= theory_max_radius
-        if (r <= theory_max_radius) {            
+        if (r <= theory_max_radius) {
             int ApplyCorotatingEField = 0;
             // for r inside conducting boundary, apply corotating efield
             if (r <= corotatingE_maxradius) ApplyCorotatingEField = 1;
@@ -304,9 +304,9 @@ public:
             Bxp = Bx_theory;
             Byp = By_theory;
             Bzp = Bz_theory;
-        }           
+        }
     }
-   
+
 
     /** Compute Cartesian components corresponding to i, j, k based on the staggering,
         ixType, and the domain_lo and cell size, dx.

--- a/Source/Particles/PulsarParameters.H
+++ b/Source/Particles/PulsarParameters.H
@@ -156,7 +156,6 @@ public:
         Bphi   = 0.0;
     }
 
-
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     static void getExternalEBOnParticle( amrex::Real const r, amrex::Real const theta, amrex::Real const phi,
                                          const int AddExternalMonopoleOnly, const int AddPulsarVacuumEFields,

--- a/Source/Particles/PulsarParameters.cpp
+++ b/Source/Particles/PulsarParameters.cpp
@@ -149,7 +149,7 @@ Pulsar::ReadParameters () {
     }
     m_corotatingE_maxradius = m_R_star;
     m_enforceDipoleB_maxradius = m_R_star;
-    pp.query("corotatingE_maxradius", m_corotatingE_maxradius);  
+    pp.query("corotatingE_maxradius", m_corotatingE_maxradius);
     pp.query("enforceDipoleB_maxradius", m_enforceDipoleB_maxradius);
     pp.query("init_dipoleBfield", m_do_InitializeGrid_with_Pulsar_Bfield);
     amrex::Print() << " init dipole : " << m_do_InitializeGrid_with_Pulsar_Bfield << "\n";
@@ -196,7 +196,7 @@ Pulsar::ReadParameters () {
     }
     pp.query("AddVacuumEFieldsIntAndExt", m_AddVacuumEFieldsIntAndExt );
     pp.query("AddVacuumBFieldsIntAndExt", m_AddVacuumBFieldsIntAndExt );
-    m_injection_endtime = 1000; // 1000 s upper limit 
+    m_injection_endtime = 1000; // 1000 s upper limit
     pp.query("ParticleInjectionEndTime",m_injection_endtime);
 }
 
@@ -367,7 +367,7 @@ Pulsar::InitializeExternalPulsarFieldsOnGrid ( amrex::MultiFab *mfx, amrex::Mult
         amrex::Array4<amrex::Real> const& mfy_arr = mfy->array(mfi);
         amrex::Array4<amrex::Real> const& mfz_arr = mfz->array(mfi);
         amrex::Array4<amrex::Real> const& conductor = m_conductor_fp[lev]->array(mfi);
- 
+
         amrex::ParallelFor (tbx, tby, tbz,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                 amrex::Real x, y, z;
@@ -891,7 +891,7 @@ void
 Pulsar::SetTangentialEforInternalConductor( std::array <std::unique_ptr<amrex::MultiFab>, 3> &Efield,
                                 const int lev, const amrex::Real a_dt)
 {
-    amrex::ignore_unused(a_dt); 
+    amrex::ignore_unused(a_dt);
     if (m_do_conductor == false) return;
     amrex::IntVect x_nodal_flag = Efield[0]->ixType().toIntVect();
     amrex::IntVect y_nodal_flag = Efield[1]->ixType().toIntVect();

--- a/Source/Particles/PulsarParameters.cpp
+++ b/Source/Particles/PulsarParameters.cpp
@@ -201,8 +201,31 @@ Pulsar::ReadParameters () {
 }
 
 void
+Pulsar::InitDataAtRestart ()
+{
+    amrex::Print() << " initialize data at restar \n";
+    auto & warpx = WarpX::GetInstance();
+    const int nlevs_max = warpx.maxLevel() + 1;
+    if (m_do_conductor == true) {
+        m_conductor_fp.resize(nlevs_max);
+        amrex::IntVect conductor_nodal_flag = amrex::IntVect::TheNodeVector();
+        const int ncomps = 1;
+        for (int lev = 0; lev < nlevs_max; ++lev) {
+            amrex::BoxArray ba = warpx.boxArray(lev);
+            amrex::DistributionMapping dm = warpx.DistributionMap(lev);
+            const amrex::IntVect ng_EB_alloc = warpx.getngEB() + amrex::IntVect::TheNodeVector()*2;
+            m_conductor_fp[lev] = std::make_unique<amrex::MultiFab>(
+                                    amrex::convert(ba,conductor_nodal_flag), dm, ncomps, ng_EB_alloc);
+            InitializeConductorMultifabUsingParser(m_conductor_fp[lev].get(), m_conductor_parser->compile<3>(), lev);
+        }
+    }
+}
+
+
+void
 Pulsar::InitData ()
 {
+    amrex::Print() << " init data at begining \n";
     auto & warpx = WarpX::GetInstance();
     const int nlevs_max = warpx.maxLevel() + 1;
     if (m_do_conductor == true) {

--- a/Source/Particles/PulsarParameters.cpp
+++ b/Source/Particles/PulsarParameters.cpp
@@ -203,7 +203,6 @@ Pulsar::ReadParameters () {
 void
 Pulsar::InitDataAtRestart ()
 {
-    amrex::Print() << " initialize data at restar \n";
     auto & warpx = WarpX::GetInstance();
     const int nlevs_max = warpx.maxLevel() + 1;
     if (m_do_conductor == true) {
@@ -225,7 +224,6 @@ Pulsar::InitDataAtRestart ()
 void
 Pulsar::InitData ()
 {
-    amrex::Print() << " init data at begining \n";
     auto & warpx = WarpX::GetInstance();
     const int nlevs_max = warpx.maxLevel() + 1;
     if (m_do_conductor == true) {


### PR DESCRIPTION
[inputs.corotating.3d.PM_restart.txt](https://github.com/RevathiJambunathan/WarpX/files/8613899/inputs.corotating.3d.PM_restart.txt)
The difference is plotfiles without and with restart is 0 on the cpu (without omp)
and below machine precision on the gpu (minor differences are due to thread execution order as discussed with @atmyers )
